### PR TITLE
Adds retry loop when attempting to get an element

### DIFF
--- a/src/FlaUI.Core/Elements/Infrastructure/Element.cs
+++ b/src/FlaUI.Core/Elements/Infrastructure/Element.cs
@@ -145,7 +145,7 @@ namespace FlaUI.Core.Elements.Infrastructure
         /// </summary>
         public Element[] FindAll(TreeScope treeScope, ConditionBase condition)
         {
-            return FindAll(treeScope, condition, TimeSpan.FromMilliseconds(200));
+            return FindAll(treeScope, condition, Retry.DefaultRetryFor);
         }
 
         /// <summary> 
@@ -164,7 +164,7 @@ namespace FlaUI.Core.Elements.Infrastructure
         /// </summary>
         public Element FindFirst(TreeScope treeScope, ConditionBase condition)
         {
-            return FindFirst(treeScope, condition, TimeSpan.FromMilliseconds(200));
+            return FindFirst(treeScope, condition, Retry.DefaultRetryFor);
         }
 
         /// <summary> 

--- a/src/FlaUI.Core/Elements/Infrastructure/Element.cs
+++ b/src/FlaUI.Core/Elements/Infrastructure/Element.cs
@@ -5,6 +5,8 @@ using FlaUI.Core.Identifiers;
 using FlaUI.Core.Shapes;
 using FlaUI.Core.WindowsAPI;
 using System;
+using FlaUI.Core.Exceptions;
+using FlaUI.Core.Tools;
 using GdiColor = System.Drawing.Color;
 using WpfColor = System.Windows.Media.Color;
 
@@ -143,7 +145,18 @@ namespace FlaUI.Core.Elements.Infrastructure
         /// </summary>
         public Element[] FindAll(TreeScope treeScope, ConditionBase condition)
         {
-            return AutomationObject.FindAll(treeScope, condition);
+            return FindAll(treeScope, condition, TimeSpan.FromMilliseconds(200));
+        }
+
+        /// <summary> 
+        /// Finds all elements in the given treescope and condition within the given timeout.
+        /// </summary> 
+        public Element[] FindAll(TreeScope treeScope, ConditionBase condition, TimeSpan timeOut)
+        {
+            Predicate<Element[]> shouldRetry = elements => elements.Length > 0;
+            Func<Element[]> func = () => AutomationObject.FindAll(treeScope, condition);
+
+            return Retry.For(func, shouldRetry, timeOut);
         }
 
         /// <summary>
@@ -151,7 +164,18 @@ namespace FlaUI.Core.Elements.Infrastructure
         /// </summary>
         public Element FindFirst(TreeScope treeScope, ConditionBase condition)
         {
-            return AutomationObject.FindFirst(treeScope, condition);
+            return FindFirst(treeScope, condition, TimeSpan.FromMilliseconds(200));
+        }
+
+        /// <summary> 
+        /// Finds the first element which is in the given treescope and matches the condition within the given timeout period. 
+        /// </summary> 
+        public Element FindFirst(TreeScope treeScope, ConditionBase condition, TimeSpan timeOut)
+        {
+            Predicate<Element> shouldRetry = element => element == null;
+            Func<Element> func = () => AutomationObject.FindFirst(treeScope, condition);
+
+            return Retry.For(func, shouldRetry, timeOut);
         }
 
         /// <summary>

--- a/src/FlaUI.Core/FlaUI.Core.csproj
+++ b/src/FlaUI.Core/FlaUI.Core.csproj
@@ -158,6 +158,7 @@
     <Compile Include="Shapes\ShapeBase.cs" />
     <Compile Include="Tools\ComCallWrapper.cs" />
     <Compile Include="Tools\ExtensionMethods.cs" />
+    <Compile Include="Tools\Retry.cs" />
     <Compile Include="Tools\SystemProductNameFetcher.cs" />
     <Compile Include="Tools\WindowsStoreAppLauncher.cs" />
     <Compile Include="WindowsAPI\Constants.cs" />

--- a/src/FlaUI.Core/Tools/Retry.cs
+++ b/src/FlaUI.Core/Tools/Retry.cs
@@ -5,6 +5,7 @@ namespace FlaUI.Core.Tools
 {
     public static class Retry
     {
+        public static readonly TimeSpan DefaultRetryFor = TimeSpan.FromMilliseconds(1000);
         private static readonly TimeSpan DefaultRetryInterval = TimeSpan.FromMilliseconds(200);
 
         public static void For(Action action, TimeSpan retryFor, TimeSpan? retryInterval = null)
@@ -43,8 +44,10 @@ namespace FlaUI.Core.Tools
                     continue;
                 }
 
-                if (!shouldRetry(element))
-                    return element;
+               if (!shouldRetry(element))
+               {
+                  return element;
+               }
             }
 
             return func();

--- a/src/FlaUI.Core/Tools/Retry.cs
+++ b/src/FlaUI.Core/Tools/Retry.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading;
+
+namespace FlaUI.Core.Tools
+{
+    public static class Retry
+    {
+        private static readonly TimeSpan DefaultRetryInterval = TimeSpan.FromMilliseconds(200);
+
+        public static void For(Action action, TimeSpan retryFor, TimeSpan? retryInterval = null)
+        {
+            var startTime = DateTime.Now;
+            while (DateTime.Now.Subtract(startTime).TotalMilliseconds < retryFor.TotalMilliseconds)
+            {
+                try
+                {
+                    action();
+                    return;
+                }
+                catch (Exception)
+                {
+                    Thread.Sleep(retryInterval ?? DefaultRetryInterval);
+                }
+            }
+
+            action();
+        }
+
+        public static T For<T>(Func<T> func, Predicate<T> shouldRetry, TimeSpan retryFor,
+            TimeSpan? retryInterval = null)
+        {
+            var startTime = DateTime.Now;
+            while (DateTime.Now.Subtract(startTime).TotalMilliseconds < retryFor.TotalMilliseconds)
+            {
+                T element;
+                try
+                {
+                    element = func();
+                }
+                catch (Exception)
+                {
+                    Thread.Sleep(retryInterval ?? DefaultRetryInterval);
+                    continue;
+                }
+
+                if (!shouldRetry(element))
+                    return element;
+            }
+
+            return func();
+        }
+    }
+}


### PR DESCRIPTION
This adds a retry loop when attempting to get an element so that the user can set a timeout period. This mirrors the functionality in white and selenium. This is the third pull which takes into consideration the UIA2 and UIA3 changes.