### PR TITLE
WIP: working on custom patterns and properties

### DIFF
--- a/src/FlaUI.Core/AutomationElementBase.cs
+++ b/src/FlaUI.Core/AutomationElementBase.cs
@@ -1,0 +1,98 @@
+﻿using FlaUI.Core.Elements;
+using FlaUI.Core.Exceptions;
+using FlaUI.Core.Identifiers;
+using System;
+
+namespace FlaUI.Core
+{
+    public abstract class AutomationElementBase
+    {
+        protected AutomationElementBase(AutomationBase automation)
+        {
+            Automation = automation;
+            InitializeInformation();
+        }
+
+        /// <summary>
+        /// Underlying <see cref="AutomationBase"/> object where this element belongs to
+        /// </summary>
+        public AutomationBase Automation { get; private set; }
+
+        /// <summary>
+        /// Basic information about this element (cached)
+        /// </summary>
+        public IAutomationElementInformation Cached { get; private set; }
+
+        /// <summary>
+        /// Basic information about this element (realtime)
+        /// </summary>
+        public IAutomationElementInformation Current { get; private set; }
+
+        /// <summary>
+        /// Gets the desired property value. Ends in an exception if the property is not supported.
+        /// </summary>
+        public object GetPropertyValue(PropertyId property, bool cached)
+        {
+            return GetPropertyValue<object>(property, cached);
+        }
+
+        public T GetPropertyValue<T>(PropertyId property, bool cached)
+        {
+            var value = InternalGetPropertyValue(property.Id, cached, false);
+            if (value == Automation.NotSupportedValue)
+            {
+                throw new PropertyNotSupportedException(String.Format("Property '{0}' not supported", property.Name), property);
+            }
+            return property.Convert<T>(value);
+        }
+
+        /// <summary>
+        /// Gets the desired property value or the default value, if the property is not supported
+        /// </summary>
+        public object SafeGetPropertyValue(PropertyId property, bool cached)
+        {
+            return SafeGetPropertyValue<object>(property, cached);
+        }
+
+        public T SafeGetPropertyValue<T>(PropertyId property, bool cached)
+        {
+            var value = InternalGetPropertyValue(property.Id, cached, true);
+            return property.Convert<T>(value);
+        }
+
+        /// <summary>
+        /// Tries to get the property value. Fails if the property is not supported.
+        /// </summary>
+        public bool TryGetPropertyValue(PropertyId property, bool cached, out object value)
+        {
+            return TryGetPropertyValue<object>(property, cached, out value);
+        }
+
+        public bool TryGetPropertyValue<T>(PropertyId property, bool cached, out T value)
+        {
+            var tmp = InternalGetPropertyValue(property.Id, cached, false);
+            if (tmp == Automation.NotSupportedValue)
+            {
+                value = default(T);
+                return false;
+            }
+            value = property.Convert<T>(tmp);
+            return true;
+        }
+
+        protected abstract object InternalGetPropertyValue(int propertyId, bool cached, bool useDefaultIfNotSupported);
+
+        protected abstract IAutomationElementInformation CreateInformation(bool cached);
+
+        private void InitializeInformation()
+        {
+            Cached = CreateInformation(true);
+            Current = CreateInformation(false);
+        }
+
+        public static Clickable AsClickable(AutomationElementBase automationElement)
+        {
+            return automationElement == null ? null : new Clickable(automationElement);
+        }
+    }
+}

--- a/src/FlaUI.Core/AutomationLibraryType.cs
+++ b/src/FlaUI.Core/AutomationLibraryType.cs
@@ -1,0 +1,8 @@
+﻿namespace FlaUI.Core
+{
+    public enum AutomationLibraryType
+    {
+        UIA2,
+        UIA3,
+    }
+}

--- a/src/FlaUI.Core/Elements/ProgressBar.cs
+++ b/src/FlaUI.Core/Elements/ProgressBar.cs
@@ -1,0 +1,33 @@
+﻿using FlaUI.Core.Patterns;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class ProgressBar : AutomationElement
+    {
+        public ProgressBar(Automation automation, UIA.IUIAutomationElement nativeElement)
+            : base(automation, nativeElement)
+        {
+        }
+
+        public RangeValuePattern RangeValuePattern
+        {
+            get { return PatternFactory.GetRangeValuePattern(); }
+        }
+
+        public double Minimum
+        {
+            get { return RangeValuePattern.Current.Minimum; }
+        }
+
+        public double Maximum
+        {
+            get { return RangeValuePattern.Current.Maximum; }
+        }
+
+        public double Value
+        {
+            get { return RangeValuePattern.Current.Value; }
+        }
+    }
+}

--- a/src/FlaUI.Core/Elements/RadioButton.cs
+++ b/src/FlaUI.Core/Elements/RadioButton.cs
@@ -1,0 +1,10 @@
+﻿using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class RadioButton : SelectionItem
+    {
+        public RadioButton(Automation automation, UIA.IUIAutomationElement nativeElement)
+            : base(automation, nativeElement) { }
+    }
+}

--- a/src/FlaUI.Core/Elements/SelectionItem.cs
+++ b/src/FlaUI.Core/Elements/SelectionItem.cs
@@ -1,0 +1,43 @@
+﻿using FlaUI.Core.Exceptions;
+using FlaUI.Core.Patterns;
+using System;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    /// <summary>
+    /// An UI-item which supports the <see cref="SelectionItemPattern"/>
+    /// </summary>
+    public class SelectionItem : AutomationElement
+    {
+        public SelectionItem(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        public SelectionItemPattern SelectionItemPattern
+        {
+            get { return PatternFactory.GetSelectionItemPattern(); }
+        }
+
+        public bool IsSelected
+        {
+            get { return SelectionItemPattern.Current.IsSelected; }
+            set
+            {
+                if (IsSelected == value) return;
+                if (value && !IsSelected)
+                {
+                    Select();
+                }
+            }
+        }
+
+        public void Select()
+        {
+            var selectionItemPattern = SelectionItemPattern;
+            if (selectionItemPattern == null)
+            {
+                throw new MethodNotSupportedException(String.Format("Select on '{0}' is not supported", ToString()));
+            }
+            selectionItemPattern.Select();
+        }
+    }
+}

--- a/src/FlaUI.Core/Elements/Slider.cs
+++ b/src/FlaUI.Core/Elements/Slider.cs
@@ -1,0 +1,124 @@
+﻿using FlaUI.Core.Conditions;
+using FlaUI.Core.Definitions;
+using FlaUI.Core.Patterns;
+using FlaUI.Core.WindowsAPI;
+using System;
+using System.Globalization;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class Slider : AutomationElement
+    {
+        public Slider(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        public Thumb Thumb
+        {
+            get { return FindFirst(TreeScope.Children, ConditionFactory.ByControlType(ControlType.Thumb)).AsThumb(); }
+        }
+
+        public virtual double Value { get; set; }
+
+        public void SmallIncrement()
+        {
+            Automation.Keyboard.PressVirtualKeyCode(VirtualKeyShort.RIGHT);
+        }
+
+        public void SmallDecrement()
+        {
+            Automation.Keyboard.PressVirtualKeyCode(VirtualKeyShort.LEFT);
+        }
+
+        public virtual void LargeIncrement() { }
+
+        public virtual void LargeDecrement() { }
+    }
+
+    public class WinFormsSlider : Slider
+    {
+        public WinFormsSlider(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        private ValuePattern ValuePattern { get { return PatternFactory.GetValuePattern(); } }
+
+        private Button LargeIncreaseButton
+        {
+            get
+            {
+                var buttons = FindAll(TreeScope.Children, ConditionFactory.ByControlType(ControlType.Button));
+                foreach (var button in buttons)
+                {
+                    if (button.Current.BoundingRectangle.Left > Thumb.Current.BoundingRectangle.Left)
+                    {
+                        return button.AsButton();
+                    }
+                }
+                return null;
+            }
+        }
+
+        private Button LargeDecreaseButton
+        {
+            get
+            {
+                var buttons = FindAll(TreeScope.Children, ConditionFactory.ByControlType(ControlType.Button));
+                foreach (var button in buttons)
+                {
+                    if (button.Current.BoundingRectangle.Right < Thumb.Current.BoundingRectangle.Right)
+                    {
+                        return button.AsButton();
+                    }
+                }
+                return null;
+            }
+        }
+
+        public override double Value
+        {
+            get { return Convert.ToDouble(ValuePattern.Current.Value); }
+            set { ValuePattern.SetValue(value.ToString(CultureInfo.InvariantCulture)); }
+        }
+
+        public override void LargeIncrement()
+        {
+            LargeIncreaseButton.Click(false);
+        }
+
+        public override void LargeDecrement()
+        {
+            LargeDecreaseButton.Click(false);
+        }
+    }
+
+    public class WpfSlider : Slider
+    {
+        public WpfSlider(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        private RangeValuePattern RangeValuePattern { get { return PatternFactory.GetRangeValuePattern(); } }
+
+        private Button LargeIncreaseButton
+        {
+            get { return FindFirst(TreeScope.Children, ConditionFactory.ByAutomationId("IncreaseLarge")).AsButton(); }
+        }
+
+        private Button LargeDecreaseButton
+        {
+            get { return FindFirst(TreeScope.Children, ConditionFactory.ByAutomationId("DecreaseLarge")).AsButton(); }
+        }
+
+        public override double Value
+        {
+            get { return RangeValuePattern.Current.Value; }
+            set { RangeValuePattern.SetValue(value); }
+        }
+
+        public override void LargeIncrement()
+        {
+            LargeIncreaseButton.Click(false);
+        }
+
+        public override void LargeDecrement()
+        {
+            LargeDecreaseButton.Click(false);
+        }
+    }
+}

--- a/src/FlaUI.Core/Elements/Tab.cs
+++ b/src/FlaUI.Core/Elements/Tab.cs
@@ -1,0 +1,81 @@
+﻿using FlaUI.Core.Conditions;
+using FlaUI.Core.Definitions;
+using System;
+using System.Linq;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class Tab : AutomationElement
+    {
+        public Tab(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        /// <summary>
+        /// The currently selected <see cref="TabItem"/>
+        /// </summary>
+        public TabItem SelectedTabItem
+        {
+            get { return TabItems.FirstOrDefault(t => t.IsSelected); }
+        }
+
+        /// <summary>
+        /// The index of the currently selected <see cref="TabItem"/>
+        /// </summary>
+        public int SelectedTabItemIndex
+        {
+            get { return GetIndexOfSelecteTabItem(); }
+        }
+
+        /// <summary>
+        /// All <see cref="TabItem"/> objects from this <see cref="Tab"/>
+        /// </summary>
+        public TabItem[] TabItems
+        {
+            get { return GetTabItems(); }
+        }
+
+        /// <summary>
+        /// Selects a <see cref="TabItem"/> by index
+        /// </summary>
+        public void SelectTabItem(int index)
+        {
+            var tabItem = TabItems[index];
+            tabItem.Select();
+        }
+
+        /// <summary>
+        /// Selects a <see cref="TabItem"/> by a give text (name property)
+        /// </summary>
+        public void SelectTabItem(string text)
+        {
+            var vabItems = TabItems;
+            var foundTabItemIndex = Array.FindIndex(vabItems, t => t.Current.Name == text);
+            if (foundTabItemIndex < 0)
+            {
+                throw new Exception(String.Format("No TabItem found with text '{0}'", text));
+            }
+            var previousSelectedTabItemIndex = SelectedTabItemIndex;
+            if (previousSelectedTabItemIndex == foundTabItemIndex)
+            {
+                // It is already selected so don't do anything
+                return;
+            }
+            // Select the item
+            vabItems[foundTabItemIndex].Select();
+        }
+
+        /// <summary>
+        /// Gets all the <see cref="TabItem"/> objects for this <see cref="Tab"/>
+        /// </summary>
+        private TabItem[] GetTabItems()
+        {
+            return FindAll(TreeScope.Children, ConditionFactory.ByControlType(ControlType.TabItem))
+                .Select(e => e.AsTabItem()).ToArray();
+        }
+
+        private int GetIndexOfSelecteTabItem()
+        {
+            return Array.FindIndex(TabItems, t => t.IsSelected);
+        }
+    }
+}

--- a/src/FlaUI.Core/Elements/TabItem.cs
+++ b/src/FlaUI.Core/Elements/TabItem.cs
@@ -1,0 +1,10 @@
+﻿using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class TabItem : SelectionItem
+    {
+        public TabItem(Automation automation, UIA.IUIAutomationElement nativeElement)
+            : base(automation, nativeElement) { }
+    }
+}

--- a/src/FlaUI.Core/Elements/Thumb.cs
+++ b/src/FlaUI.Core/Elements/Thumb.cs
@@ -1,0 +1,28 @@
+﻿using FlaUI.Core.Input;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class Thumb : AutomationElement
+    {
+        public Thumb(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        /// <summary>
+        /// Moves the slider horizontally
+        /// </summary>
+        /// <param name="distance">+ for right, - for left</param>
+        public void SlideHorizontally(int distance)
+        {
+            Automation.Mouse.DragHorizontally(MouseButton.Left, Current.BoundingRectangle.Center, distance);
+        }
+
+        /// <summary>
+        /// Moves the slider vertically
+        /// </summary>
+        /// <param name="distance">+ for down, - for up</param>
+        public void SlideVertically(int distance)
+        {
+            Automation.Mouse.DragVertically(MouseButton.Left, Current.BoundingRectangle.Center, distance);
+        }
+    }
+}

--- a/src/FlaUI.Core/Elements/Tree.cs
+++ b/src/FlaUI.Core/Elements/Tree.cs
@@ -1,0 +1,52 @@
+﻿using FlaUI.Core.Conditions;
+using FlaUI.Core.Definitions;
+using System.Linq;
+using System.Resources;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class Tree : AutomationElement
+    {
+        public Tree(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        /// <summary>
+        /// The currently selected <see cref="TreeItem"/>
+        /// </summary>
+        public TreeItem SelectedTreeItem
+        {
+            get { return SearchSelectedItem(TreeItems); }
+        }
+
+        private TreeItem SearchSelectedItem(TreeItem[] treeItems)
+        {
+            // Search for a selected item in the direct children
+            var directSelectedItem = treeItems.FirstOrDefault(t => t.IsSelected);
+            if (directSelectedItem != null) { return directSelectedItem; }
+            // Loop thru the children and search in their children
+            foreach (var treeItem in treeItems)
+            {
+                var selectedInChildItem = SearchSelectedItem(treeItem.TreeItems);
+                if (selectedInChildItem != null) { return selectedInChildItem; }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// All child <see cref="TreeItem"/> objects from this <see cref="Tree"/>
+        /// </summary>
+        public TreeItem[] TreeItems
+        {
+            get { return GetTreeItems(); }
+        }
+
+        /// <summary>
+        /// Gets all the <see cref="TreeItem"/> objects for this <see cref="Tree"/>
+        /// </summary>
+        private TreeItem[] GetTreeItems()
+        {
+            return FindAll(TreeScope.Children, ConditionFactory.ByControlType(ControlType.TreeItem))
+                .Select(e => e.AsTreeItem()).ToArray();
+        }
+    }
+}

--- a/src/FlaUI.Core/Elements/TreeItem.cs
+++ b/src/FlaUI.Core/Elements/TreeItem.cs
@@ -1,0 +1,70 @@
+﻿using FlaUI.Core.Conditions;
+using FlaUI.Core.Definitions;
+using System;
+using System.Linq;
+using FlaUI.Core.Patterns;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.Core.Elements
+{
+    public class TreeItem : SelectionItem
+    {
+        public TreeItem(Automation automation, UIA.IUIAutomationElement nativeElement) : base(automation, nativeElement) { }
+
+        public ExpandCollapsePattern ExpandCollapsePattern
+        {
+            get { return PatternFactory.GetExpandCollapsePattern(); }
+        }
+        /// <summary>
+        /// All child <see cref="TreeItem"/> objects from this <see cref="TreeItem"/>
+        /// </summary>
+        public TreeItem[] TreeItems
+        {
+            get { return GetTreeItems(); }
+        }
+
+        /// <summary>
+        /// The text of the <see cref="TreeItem"/>
+        /// </summary>
+        public string Text
+        {
+            get
+            {
+                var value = Current.Name;
+                if (String.IsNullOrEmpty(value) || value.Contains("System.Windows.Controls.TreeViewItem"))
+                {
+                    var textElement = FindFirst(TreeScope.Children, ConditionFactory.ByControlType(ControlType.Text));
+                    return textElement == null ? String.Empty : textElement.Current.Name;
+                }
+                return value;
+            }
+        }
+
+        public void Expand()
+        {
+            var expandCollapsePattern = ExpandCollapsePattern;
+            if (expandCollapsePattern != null)
+            {
+                expandCollapsePattern.Expand();
+            }
+        }
+
+        public void Collapse()
+        {
+            var expandCollapsePattern = ExpandCollapsePattern;
+            if (expandCollapsePattern != null)
+            {
+                expandCollapsePattern.Expand();
+            }
+        }
+
+        /// <summary>
+        /// Gets all the <see cref="TreeItem"/> objects for this <see cref="TreeItem"/>
+        /// </summary>
+        private TreeItem[] GetTreeItems()
+        {
+            return FindAll(TreeScope.Children, ConditionFactory.ByControlType(ControlType.TreeItem))
+                .Select(e => e.AsTreeItem()).ToArray();
+        }
+    }
+}

--- a/src/FlaUI.Core/IAutomationElementInformation.cs
+++ b/src/FlaUI.Core/IAutomationElementInformation.cs
@@ -1,0 +1,11 @@
+﻿using FlaUI.Core.Shapes;
+
+namespace FlaUI.Core
+{
+    public interface IAutomationElementInformation
+    {
+        string AutomationId { get; }
+        Rectangle BoundingRectangle { get; }
+        string Name { get; }
+    }
+}

--- a/src/FlaUI.Core/InformationBase2.cs
+++ b/src/FlaUI.Core/InformationBase2.cs
@@ -1,0 +1,37 @@
+﻿using FlaUI.Core.Identifiers;
+
+namespace FlaUI.Core
+{
+    /// <summary>
+    /// Base class for information objects
+    /// </summary>
+    public abstract class InformationBase2
+    {
+        /// <summary>
+        /// The element this information belongs to
+        /// </summary>
+        protected AutomationElementBase AutomationElement { get; private set; }
+
+        /// <summary>
+        /// Flag to indicate if the information is cached or not
+        /// </summary>
+        protected bool Cached { get; private set; }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        protected InformationBase2(AutomationElementBase automationElement, bool cached)
+        {
+            AutomationElement = automationElement;
+            Cached = cached;
+        }
+
+        /// <summary>
+        /// Shortcut to get the property 
+        /// </summary>
+        protected T Get<T>(PropertyId property)
+        {
+            return AutomationElement.SafeGetPropertyValue<T>(property, Cached);
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/AttributeDrivenPatternHandler.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/AttributeDrivenPatternHandler.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Castle.DynamicProxy;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    public class AttributeDrivenPatternHandler : IUIAutomationPatternHandler
+    {
+        private static readonly ProxyGenerator _proxyGenerator = new ProxyGenerator();
+        private readonly CustomPatternSchemaBase _schema;
+
+        public AttributeDrivenPatternHandler(CustomPatternSchemaBase schema)
+        {
+            _schema = schema;
+        }
+
+        public void CreateClientWrapper(IUIAutomationPatternInstance pPatternInstance, out object pClientWrapper)
+        {
+            var interceptor = new PatternClientInstanceInterceptor(_schema, pPatternInstance);
+            pClientWrapper = _proxyGenerator.CreateInterfaceProxyWithoutTarget(_schema.PatternClientInterface, interceptor);
+        }
+
+        public void Dispatch(object pTarget, uint index, UIAutomationParameter[] pParams, uint cParams)
+        {
+            ISchemaMember dispatchingMember = _schema.GetMemberByIndex(index);
+            if (dispatchingMember == null)
+                throw new NotSupportedException("Dispatching of this method is not supported");
+
+            dispatchingMember.DispatchCallToProvider(pTarget, new UiaParameterListHelper(pParams));
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternClientInstanceInterceptor.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternClientInstanceInterceptor.cs
@@ -2,10 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Windows.Automation;
 using Castle.DynamicProxy;
+using Interop.UIAutomationClient;
 using Interop.UIAutomationCore;
-using UIAutomationClient;
 
 namespace ManagedUiaCustomizationCore
 {

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternClientInstanceInterceptor.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternClientInstanceInterceptor.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Automation;
+using Castle.DynamicProxy;
+using Interop.UIAutomationCore;
+using UIAutomationClient;
+
+namespace ManagedUiaCustomizationCore
+{
+    public class PatternClientInstanceInterceptor : IInterceptor
+    {
+        private readonly IUIAutomationPatternInstance _patternInstance;
+        private readonly Dictionary<string, UiaPropertyInfoHelper> _currentPropGetterNameToHelper;
+        private readonly Dictionary<string, UiaPropertyInfoHelper> _cachedPropGetterNameToHelper;
+        private readonly Dictionary<MethodInfo, UiaMethodInfoHelper> _methodInfoToHelper;
+
+        public PatternClientInstanceInterceptor(CustomPatternSchemaBase schema, IUIAutomationPatternInstance patternInstance)
+        {
+            _patternInstance = patternInstance;
+            _currentPropGetterNameToHelper = schema.Properties.ToDictionary(helper => string.Format("get_Current{0}", helper.Data.pProgrammaticName));
+            _cachedPropGetterNameToHelper = schema.Properties.ToDictionary(helper => string.Format("get_Cached{0}", helper.Data.pProgrammaticName));
+
+            // helpers are aware about provider methods, we have to map them from client-side pattern methods
+            _methodInfoToHelper = new Dictionary<MethodInfo, UiaMethodInfoHelper>();
+            foreach (var methodInfoHelper in schema.Methods)
+            {
+                var providerInfo = methodInfoHelper.ProviderMethodInfo;
+                if (providerInfo == null) continue;
+
+                var patternMethod = ProviderPatternMatcher.GetMatchingPatternMethod(schema.PatternClientInterface, providerInfo);
+                if (patternMethod != null)
+                    _methodInfoToHelper[patternMethod] = methodInfoHelper;
+            }
+        }
+
+        public void Intercept(IInvocation invocation)
+        {
+            UiaPropertyInfoHelper propHelper;
+            UiaMethodInfoHelper methodHelper;
+            if (_currentPropGetterNameToHelper.TryGetValue(invocation.Method.Name, out propHelper))
+                CallProperty(invocation, propHelper, cached: false);
+            else if (_cachedPropGetterNameToHelper.TryGetValue(invocation.Method.Name, out propHelper))
+                CallProperty(invocation, propHelper, cached: true);
+            else if (_methodInfoToHelper.TryGetValue(invocation.Method, out methodHelper))
+                CallMethod(invocation, methodHelper);
+            else
+                throw new NotSupportedException(string.Format("Method {0} is not expected", invocation.Method.Name));
+        }
+
+        private void CallProperty(IInvocation invocation, UiaPropertyInfoHelper propHelper, bool cached)
+        {
+            // it is call for CurrentXxx property
+            var param = new UiaParameterHelper(propHelper.UiaType);
+            NativeMethods.WrapUiaComCall(() => _patternInstance.GetProperty(propHelper.Index, cached ? 1 : 0, propHelper.UiaType, param.Data));
+            object value = param.Value;
+            if (invocation.Method.ReturnType == typeof(AutomationElement))
+                value = AutomationElement.Wrap((IUIAutomationElement)value);
+            invocation.ReturnValue = value;
+        }
+
+        private void CallMethod(IInvocation invocation, UiaMethodInfoHelper methodHelper)
+        {
+            if (!methodHelper.SupportsDispatch)
+                throw new InvalidOperationException("Called method {0} doesn't support automatic metadata-driven dispatch. You have to modify schema in order to use this feature so that corresponding UiaMethodInfoHelper supports dispatch.");
+            var paramList = new UiaParameterListHelper(methodHelper);
+            
+            // 1. Fill In params to paramList from invocation arguments
+            // we're using the fact that In params are always going before out params, so we may just go through 0..(cInParameters-1)
+            for (int i = 0; i < methodHelper.Data.cInParameters; i++)
+            {
+                var desc = methodHelper.PatternMethodParamDescriptions[i];
+                var idx = methodHelper.GetProviderMethodArgumentIndex(desc.Name);
+                paramList[i] = invocation.Arguments[idx];
+            }
+
+            // 2. Call patternInstance method
+            NativeMethods.WrapUiaComCall(() => _patternInstance.CallMethod(methodHelper.Index, paramList.Data, paramList.Count));
+            
+            // 3. Fill Out params back to invocation from paramList
+            for (int i = (int)methodHelper.Data.cInParameters; i < methodHelper.Data.cInParameters + methodHelper.Data.cOutParameters; i++)
+            {
+                object value = paramList[i];
+                var desc = methodHelper.PatternMethodParamDescriptions[i];
+                if (desc.Name == UiaTypesHelper.RetParamUnspeakableName)
+                {
+                    if (invocation.Method.ReturnType == typeof(AutomationElement))
+                        value = AutomationElement.Wrap((IUIAutomationElement)value);
+                    invocation.ReturnValue = value;
+                }
+                else
+                {
+                    var idx = methodHelper.GetProviderMethodArgumentIndex(desc.Name);
+                    if (invocation.Method.GetParameters()[idx].ParameterType.GetElementType() == typeof(AutomationElement))
+                        value = AutomationElement.Wrap((IUIAutomationElement)value);
+                    invocation.Arguments[idx] = value;
+                }
+            }
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternGuidAttribute.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternGuidAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace ManagedUiaCustomizationCore
+{
+    [AttributeUsage(AttributeTargets.Interface, AllowMultiple = false)]
+    public class PatternGuidAttribute : Attribute
+    {
+        /// <param name="patternGuid">Pattern would be registered in UIA under this GUID. Do not confuse with GUID of the pattern's client interface,
+        /// which is how COM would identify. Both should be applied to the client interface and should be different</param>
+        public PatternGuidAttribute(string patternGuid)
+        {
+            Value = new Guid(patternGuid);
+        }
+
+        public Guid Value { get; private set; }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternMethodAttribute.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternMethodAttribute.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace ManagedUiaCustomizationCore
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public class PatternMethodAttribute : Attribute
+    {
+        /// <summary>
+        /// true if UI Automation should set the focus on the object before calling the method; otherwise false.
+        /// </summary>
+        public bool DoSetFocus { get; set; }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternPropertyAttribute.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/PatternPropertyAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace ManagedUiaCustomizationCore
+{
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
+    public class PatternPropertyAttribute : Attribute
+    {
+        public PatternPropertyAttribute(string guid)
+        {
+            Guid = new Guid(guid);
+        }
+
+        public Guid Guid { get; private set; }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/ProviderPatternMatcher.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/ProviderPatternMatcher.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Windows.Automation;
+
+namespace ManagedUiaCustomizationCore
+{
+    internal class ProviderPatternMatcher
+    {
+        internal static MethodInfo GetMatchingPatternMethod(Type patternInterface, MethodInfo providerMethodInfo)
+        {
+            return patternInterface.GetMethods()
+                                   .Where(m => m.Name == providerMethodInfo.Name)
+                                   .FirstOrDefault(mi => MethodsMatch(providerMethodInfo, mi));
+        }
+
+        private static bool MethodsMatch(MethodInfo providerMethod, MethodInfo patternMethod)
+        {
+            var providerParamTypes = providerMethod.GetParameters().Select(param => param.ParameterType).ToArray();
+            var patternParamTypes = patternMethod.GetParameters().Select(param => param.ParameterType).ToArray();
+            
+            if (patternParamTypes.Length != providerParamTypes.Length) 
+                return false;
+            return Enumerable.Range(0, patternParamTypes.Length)
+                             .All(idx => ParametersMatch(providerParamTypes[idx], patternParamTypes[idx]));
+        }
+
+        internal static bool ParametersMatch(Type serverParamType, Type clientParamType)
+        {
+            if (serverParamType.IsByRef != clientParamType.IsByRef)
+                return false;
+
+            if (UiaTypesHelper.IsElementOnServerSide(serverParamType))
+            {
+                if (clientParamType.IsByRef)
+                    clientParamType = clientParamType.GetElementType();
+                return UiaTypesHelper.IsElementOnClientSide(clientParamType)
+                       || clientParamType == typeof(AutomationElement);
+            }
+
+            return serverParamType == clientParamType;
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/ProviderPatternMatcher.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/ProviderPatternMatcher.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using System.Windows.Automation;
 
 namespace ManagedUiaCustomizationCore
 {

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/ReflectionUtils.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/ReflectionUtils.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace ManagedUiaCustomizationCore
+{
+    public static class ReflectionUtils
+    {
+        internal static IEnumerable<TA> GetAttributes<TA>(this MemberInfo memberInfo)
+        {
+            return memberInfo.GetCustomAttributes(typeof(TA), true).Cast<TA>();
+        }
+
+        internal static TA GetAttribute<TA>(this MemberInfo memberInfo)
+        {
+            return memberInfo.GetAttributes<TA>().FirstOrDefault();
+        }
+
+        internal static IEnumerable<MethodInfo> GetMethodsMarkedWith<TAttribute>(this Type type)
+        {
+            return from m in type.GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                   where m.GetAttributes<TAttribute>().Any()
+                   select m;
+        }
+
+        internal static IEnumerable<PropertyInfo> GetPropertiesMarkedWith<TAttribute>(this Type type)
+        {
+            return from m in type.GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                   where m.GetAttributes<TAttribute>().Any()
+                   select m;
+        }
+
+        internal static IEnumerable<FieldInfo> GetStaticFieldsMarkedWith<TAttribute>(this Type type)
+        {
+            return from m in type.GetFields(BindingFlags.Static | BindingFlags.Public)
+                   where m.GetAttributes<TAttribute>().Any()
+                   select m;
+        }
+
+        public static Func<object, object> GetPropertyGetter(this PropertyInfo propInfo)
+        {
+            if (propInfo.GetGetMethod(false) == null)
+                throw new InvalidOperationException("Given property has no public getter");
+            var param = Expression.Parameter(typeof(object), "t");
+            var expression = Expression.Lambda<Func<object, object>>(
+                Expression.Convert(
+                    Expression.MakeMemberAccess(
+                        Expression.Convert(param, propInfo.DeclaringType),
+                        propInfo),
+                    typeof(object)),
+                param);
+            return expression.Compile();
+        }
+
+        public static MethodInfo GetMethodInfo(Expression<Action> methodCallExpression)
+        {
+            var methodCall = methodCallExpression.Body as MethodCallExpression;
+            return methodCall.Method;
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/StandalonePropertyAttribute.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/StandalonePropertyAttribute.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace ManagedUiaCustomizationCore
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class StandalonePropertyAttribute : Attribute
+    {
+        public Guid Guid { get; private set; }
+        public Type Type { get; private set; }
+
+        public StandalonePropertyAttribute(string guid, Type type)
+        {
+            Type = type;
+            Guid = new Guid(guid);
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/TypeMember.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/TypeMember.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace ManagedUiaCustomizationCore
+{
+    public static class TypeMember<TClass>
+    {
+        public static PropertyInfo PropertyInfo<TProp>(Expression<Func<TClass, TProp>> expression)
+        {
+            var body = expression.Body as MemberExpression;
+
+            if (body == null)
+                throw new ArgumentException("'expression' should be a property expression");
+
+            var propInfo = body.Member as PropertyInfo;
+
+            if (propInfo == null)
+                throw new ArgumentException("'expression' should be a property expression");
+
+            return propInfo;
+        }
+
+        public static Func<object, object> GetPropertyGetter<TProp>(Expression<Func<TClass, TProp>> expression)
+        {
+            var propertyInfo = PropertyInfo(expression);
+            return propertyInfo.GetPropertyGetter();
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/UiaTypesHelper.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/UiaTypesHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using Interop.UIAutomationClient;
 using Interop.UIAutomationCore;
-using UIAutomationClient;
 using IRawElementProviderSimple = Interop.UIAutomationCore.IRawElementProviderSimple;
 
 namespace ManagedUiaCustomizationCore

--- a/src/FlaUI.Custom/AttributeDrivenPatternHelpers/UiaTypesHelper.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternHelpers/UiaTypesHelper.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Collections.Generic;
+using Interop.UIAutomationCore;
+using UIAutomationClient;
+using IRawElementProviderSimple = Interop.UIAutomationCore.IRawElementProviderSimple;
+
+namespace ManagedUiaCustomizationCore
+{
+    public static class UiaTypesHelper
+    {
+        public const string RetParamUnspeakableName = "<>retValue";
+
+        private static readonly Dictionary<Type, UIAutomationType> _typeMapping
+            = new Dictionary<Type, UIAutomationType>
+              {
+                  {typeof(int), UIAutomationType.UIAutomationType_Int},
+                  {typeof(bool), UIAutomationType.UIAutomationType_Bool},
+                  {typeof(string), UIAutomationType.UIAutomationType_String},
+                  {typeof(double), UIAutomationType.UIAutomationType_Double},
+              };
+
+        public static UIAutomationType TypeToAutomationType(Type type)
+        {
+            if (IsElementOnServerSide(type))
+                return UIAutomationType.UIAutomationType_Element;
+            if (type.IsEnum && type.GetEnumUnderlyingType() == typeof(int))
+                type = typeof(int);
+            UIAutomationType res;
+            if (_typeMapping.TryGetValue(type, out res))
+                return res;
+            throw new NotSupportedException("Provided type is not supported");
+        }
+
+        public static UIAutomationType TypeToOutAutomationType(Type type)
+        {
+            return TypeToAutomationType(type) | UIAutomationType.UIAutomationType_Out;
+        }
+
+        public static bool IsElementOnServerSide(Type type)
+        {
+            // strip ref/out modifier if needed, because it doesn't have GUID of underlying element type
+            if (type.IsByRef) 
+                type = type.GetElementType();
+            return type.GUID == typeof(IRawElementProviderSimple).GUID;
+        }
+
+        public static bool IsElementOnClientSide(Type type)
+        {
+            // strip ref/out modifier if needed, because it doesn't have GUID of underlying element type
+            if (type.IsByRef)
+                type = type.GetElementType();
+            return type.GUID == typeof(IUIAutomationElement).GUID;
+        }
+
+        public static bool IsInType(UIAutomationType type)
+        {
+            return !IsOutType(type);
+        }
+
+        public static bool IsOutType(UIAutomationType type)
+        {
+            return (type & UIAutomationType.UIAutomationType_Out) != 0;
+        }
+    }
+}

--- a/src/FlaUI.Custom/AttributeDrivenPatternSchema.cs
+++ b/src/FlaUI.Custom/AttributeDrivenPatternSchema.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    public class AttributeDrivenPatternSchema : CustomPatternSchemaBase
+    {
+        private readonly Type _patternProviderInterface;
+        private readonly Type _patternClientInterface;
+        private readonly Guid _patternGuid;
+        private readonly string _patternName;
+        private readonly UiaMethodInfoHelper[] _methods;
+        private readonly UiaPropertyInfoHelper[] _properties;
+        private readonly AttributeDrivenPatternHandler _handler;
+
+        public AttributeDrivenPatternSchema(Type patternProviderInterface, Type patternClientInterface)
+        {
+            if (!patternProviderInterface.IsInterface)
+                throw new ArgumentException("Provided pattern provider type should be an interface", "patternProviderInterface");
+            if (!patternClientInterface.IsInterface)
+                throw new ArgumentException("Provided pattern client type should be an interface", "patternClientInterface");
+            _patternProviderInterface = patternProviderInterface;
+            _patternClientInterface = patternClientInterface;
+
+            var patternClientName = _patternClientInterface.Name;
+            if (!patternClientName.EndsWith("Pattern") || !patternClientName.StartsWith("I"))
+                throw new ArgumentException("Pattern client interface named incorrectly, should be IXxxPattern", "patternClientInterface");
+            var baseName = patternClientName.Substring(1, patternClientName.Length - "I".Length - "Pattern".Length);
+            if (_patternProviderInterface.Name != string.Format("I{0}Provider", baseName))
+                throw new ArgumentException(string.Format("Pattern provider interface named incorrectly, should be I{0}Provider", baseName));
+            _patternName = string.Format("{0}Pattern", baseName);
+
+            var patternGuidAttr = _patternProviderInterface.GetAttribute<PatternGuidAttribute>();
+            if (patternGuidAttr == null) throw new ArgumentException("Provided type should be marked with PatternGuid attribute");
+            _patternGuid = patternGuidAttr.Value;
+
+            _methods = patternProviderInterface.GetMethodsMarkedWith<PatternMethodAttribute>().Select(GetMethodHelper).ToArray();
+            _properties = patternProviderInterface.GetPropertiesMarkedWith<PatternPropertyAttribute>().Select(GetPropertyHelper).ToArray();
+            ValidateClientInterface();
+            _handler = new AttributeDrivenPatternHandler(this);
+        }
+
+        private void ValidateClientInterface()
+        {
+            var mErrors = GetMethodErrorsMsg();
+            var pErrors = GetPropertyErrosMsg();
+            if (!string.IsNullOrEmpty(mErrors) || !string.IsNullOrEmpty(pErrors))
+                throw new Exception(mErrors + pErrors);
+        }
+
+        private UiaPropertyInfoHelper GetPropertyHelper(PropertyInfo pInfo)
+        {
+            var propertyAttr = pInfo.GetAttribute<PatternPropertyAttribute>(); // can'be null as otherwise it wouldn't get into this method
+            var guid = propertyAttr.Guid;
+            var programmaticName = pInfo.Name;
+            var uiaType = UiaTypesHelper.TypeToAutomationType(pInfo.PropertyType);
+            return new UiaPropertyInfoHelper(guid, programmaticName, uiaType, pInfo.GetPropertyGetter());
+        }
+
+        private UiaMethodInfoHelper GetMethodHelper(MethodInfo mInfo)
+        {
+            var methodAttr = mInfo.GetAttribute<PatternMethodAttribute>(); // can'be null as otherwise it wouldn't get into this method
+            var doSetFocus = methodAttr.DoSetFocus;
+            return new UiaMethodInfoHelper(mInfo, doSetFocus);
+        }
+
+        public override string PatternName
+        {
+            get { return _patternName; }
+        }
+
+        public override Type PatternProviderInterface
+        {
+            get { return _patternProviderInterface; }
+        }
+
+        public override Type PatternClientInterface
+        {
+            get { return _patternClientInterface; }
+        }
+
+        public override Guid PatternGuid
+        {
+            get { return _patternGuid; }
+        }
+
+        public override UiaPropertyInfoHelper[] Properties
+        {
+            get { return _properties; }
+        }
+
+        public override UiaMethodInfoHelper[] Methods
+        {
+            get { return _methods; }
+        }
+
+        public override UiaEventInfoHelper[] Events
+        {
+            // not supported for now
+            get { return new UiaEventInfoHelper[0]; }
+        }
+
+        public override IUIAutomationPatternHandler Handler
+        {
+            get { return _handler; }
+        }
+
+        private string GetPropertyErrosMsg()
+        {
+            var propsWithErrors = new List<string>();
+            foreach (PropertyInfo providerPropInfo in _patternProviderInterface.GetProperties())
+            {
+                string providerPropName = providerPropInfo.Name;
+                var currentPropName = "Current" + providerPropName;
+                var cachedPropName = "Cached" + providerPropName;
+                var currentPropInfo = _patternClientInterface.GetProperty(currentPropName);
+                var cachedPropInfo = _patternClientInterface.GetProperty(cachedPropName);
+                if (currentPropInfo == null || cachedPropInfo == null)
+                    propsWithErrors.Add(string.Format("{0} -- doesn't have one or both matching properties in client-side pattern interface", providerPropName));
+                else if (currentPropInfo.PropertyType != cachedPropInfo.PropertyType)
+                    propsWithErrors.Add(string.Format("{0} -- Current{0} and Cached{0} properties from client-side pattern interface have different types", providerPropName));
+                else if (!ProviderPatternMatcher.ParametersMatch(providerPropInfo.PropertyType, currentPropInfo.PropertyType)) 
+                    propsWithErrors.Add(string.Format("{0} -- types of provider and client interfaces' properties don't match", providerPropName));
+            }
+            if (propsWithErrors.Count > 0)
+                return string.Format("These properties from provider interface have issues:\n{0}",
+                                     string.Join("\n", propsWithErrors));
+            return null;
+        }
+
+        private string GetMethodErrorsMsg()
+        {
+            var methodsWithErrors = (from methodInfoHelper in _methods
+                                     select methodInfoHelper.ProviderMethodInfo
+                                     into providerMethodInfo
+                                     where ProviderPatternMatcher.GetMatchingPatternMethod(_patternClientInterface, providerMethodInfo) == null
+                                     select providerMethodInfo.Name)
+                .ToList();
+
+            if (methodsWithErrors.Count > 0)
+                return string.Format("These methods from provider interface do not have matching methods in client-side pattern interface:\n{0}",
+                                     string.Join(", ", methodsWithErrors));
+            return string.Empty;
+        }
+    }
+}

--- a/src/FlaUI.Custom/AutomationPeerAugmentationHelper.cs
+++ b/src/FlaUI.Custom/AutomationPeerAugmentationHelper.cs
@@ -162,7 +162,7 @@ namespace ManagedUiaCustomizationCore
         private static void GuardUiaServerInvocation(Action invocation, Dispatcher dispatcher)
         {
             if (dispatcher == null)
-                throw new ElementNotAvailableException();
+                throw new InvalidOperationException("Dispatcher is not available. Maybe it is not a UI thread?");
             Exception remoteException = null;
             bool completed = false;
             dispatcher.Invoke(DispatcherPriority.Send, TimeSpan.FromMinutes(3.0), (Action)(() =>

--- a/src/FlaUI.Custom/AutomationPeerAugmentationHelper.cs
+++ b/src/FlaUI.Custom/AutomationPeerAugmentationHelper.cs
@@ -1,0 +1,232 @@
+﻿using System;
+using System.Collections;
+using System.Reflection;
+using System.Windows.Automation;
+using System.Windows.Automation.Peers;
+using System.Windows.Threading;
+using Castle.DynamicProxy;
+
+namespace ManagedUiaCustomizationCore
+{
+    public static class AutomationPeerAugmentationHelper
+    {
+        private static readonly ProxyGenerator _proxyGenerator = new ProxyGenerator();
+
+        public static void Register(CustomPatternSchemaBase schema)
+        {
+            //   For events AutomationPeers goes other way and list of events it can raise through 
+            // AutomationPeer.RaiseAutomationEvent() is very strictly hardcoded with switch()
+            // operator in the EventMap internal class. But it is possible to get IRawElementProviderSimple
+            // from the protected AutomationPeer.ProviderFromPeer method and use it directly via
+            // NativeMethods.UiaRaiseAutomationEvent. Basically it is the same AutomationPeer does, 
+            // so the only inconvenience would be non-standard method of raising.
+            //   Another piece required here is to replicate for AutomationPeer.ListenersExist(). Seems to
+            // fully support custom events we would have to rewrite EventsMap class. Fortunately it is small :)
+            //
+            // TODO: Add support for raising custom UIA events
+
+            RegisterPattern(schema);
+            foreach (var property in schema.Properties)
+                RegisterProperty(property);
+            if (schema.StandaloneProperties != null)
+            {
+                foreach (var uiaPropertyInfoHelper in schema.StandaloneProperties)
+                {
+                    var automationProperty = RegisterProperty(uiaPropertyInfoHelper);
+                    RegisterStandalonePropertyGetter(automationProperty);
+                }
+            }
+        }
+
+        private static void RegisterPattern(CustomPatternSchemaBase schema)
+        {
+            var automationPeerType = typeof(AutomationPeer);
+            // The only purpose of this method is to construct and correctly execute these lines of code:
+            //
+            //   var wrapper = new Wrapper(schema.PatternProviderInterface);
+            //   var wrapObject = new AutomationPeer.WrapObject(wrapper.WrapObjectReplacer);
+            //   AutomationPeer.s_patternInfo[schema.PatternId] 
+            //      = new AutomationPeer.PatternInfo(schema.PatternId, 
+            //                                       wrapObject, 
+            //                                       (PatternInterface)schema.PatternId);
+            //   AutomationPattern.Register(schema.PatternGuid, schema.PatternName);
+            //
+            //   The problem here is that AutomationPeer.WrapObject, AutomationPeer.s_patternInfo, AutomationPattern.Register
+            // and AutomationPeer.PatternInfo are not public, so we need some hardcore reflection.
+            //   Now, to be very clear, casting patternId to PatternInterface is not totally correct, 
+            // but customly registered patterns get IDs near 50000 and max PatternInterface value is 
+            // something about 20, so they won't intersect ever. On the other hand, after several hours
+            // studying AutomationPeer sources it seems unfeasible to get what we need in other way 
+            // because AutomationPeer wasn't written with extensibility in mind.
+            var patternInfoHashtableField = automationPeerType.GetField("s_patternInfo", BindingFlags.NonPublic | BindingFlags.Static);
+
+            // from AutomationPeer.cs: private delegate object WrapObject(AutomationPeer peer, object iface);
+            var wrapObjectDelegateType = automationPeerType.GetNestedType("WrapObject", BindingFlags.NonPublic);
+            var wrapper = new Wrapper(schema.PatternProviderInterface);
+            var wrapObjectReplacerMethodInfo = ReflectionUtils.GetMethodInfo(() => wrapper.WrapObjectReplacer(null, null));
+            var wrapObject = Delegate.CreateDelegate(wrapObjectDelegateType, wrapper, wrapObjectReplacerMethodInfo);
+            
+            // from AutomationPeer.cs:  
+            //private class PatternInfo
+            //{
+            //  internal int Id;
+            //  internal AutomationPeer.WrapObject WrapObject;
+            //  internal PatternInterface PatternInterface;
+
+            //  internal PatternInfo(int id, AutomationPeer.WrapObject wrapObject, PatternInterface patternInterface)
+            //  {
+            //    this.Id = id;
+            //    this.WrapObject = wrapObject;
+            //    this.PatternInterface = patternInterface;
+            //  }
+            //}
+            var patternInfoType = automationPeerType.GetNestedType("PatternInfo", BindingFlags.NonPublic);
+            var patternInfoTypeCtor = patternInfoType.GetConstructor(
+                BindingFlags.NonPublic | BindingFlags.Instance,
+                binder: null,
+                types: new[] {typeof(int), wrapObjectDelegateType, typeof(PatternInterface)},
+                modifiers: null);
+            var patternInfo = patternInfoTypeCtor.Invoke(new object[] {schema.PatternId, wrapObject, (PatternInterface)schema.PatternId});
+
+            var automationPatternType = typeof(AutomationPattern);
+            var registerMethod = automationPatternType.GetMethod("Register", BindingFlags.NonPublic | BindingFlags.Static);
+
+            using (Dispatcher.CurrentDispatcher.DisableProcessing())
+            {
+                var patternInfoHashtable = (Hashtable)patternInfoHashtableField.GetValue(null);
+                if (patternInfoHashtable.Contains(schema.PatternId)) return;
+                patternInfoHashtable[schema.PatternId] = patternInfo;
+                registerMethod.Invoke(null, new object[] {schema.PatternGuid, schema.PatternName});
+            }
+        }
+
+        private static void RegisterStandalonePropertyGetter(AutomationProperty automationProperty)
+        {
+            // With WPF Automation peers, retrieving UIA property value goes through these steps:
+            //  1. UIA request comes at ElementProxy which linked with AutomationPeer and wraps it from multithreading, COM etc
+            //  2. ElementProxy passes request to UI thread and directs it to AutomationPeer.GetPropertyValue(int propertyId)
+            //  3. AutomationPeer consults its hashtable of getters and tries to find there getter for required property. These 
+            //     getters are basically Func<AutomationPeer, object>
+            //  4. If getter is found - it is called like getter(this) from AutomationPeer, otherwise null returned
+            //
+            // Similarly to RegisterPattern() method, we need to add new item to 
+            // private static Hashtable AutomationPeer.s_propertyInfo, in order to let 3rd step from above pass correctly
+            // Like this line
+            //   AutomationPeer.s_propertyInfo[property.PropertyId] = new AutomationPeer.GetProperty(getter);
+            // where GetProperty defined in AutomationPeer as:
+            //   private delegate object GetProperty(AutomationPeer peer);
+            //
+            // Our getter will try to cast AutomationPeer to IStandalonePropertyProvider and if successful - get result from it.
+            // Otherwise returns null.
+            var automationPeerType = typeof(AutomationPeer);
+            var propertyInfoHashtableField = automationPeerType.GetField("s_propertyInfo", BindingFlags.NonPublic | BindingFlags.Static);
+            var getterDelegateType = automationPeerType.GetNestedType("GetProperty", BindingFlags.NonPublic);
+            var getterObject = new StandalonePropertyGetter(automationProperty);
+            var getterMethodInfo = ReflectionUtils.GetMethodInfo(() => getterObject.Getter(null));
+            var getter = Delegate.CreateDelegate(getterDelegateType, getterObject, getterMethodInfo);
+
+            using (Dispatcher.CurrentDispatcher.DisableProcessing())
+            {
+                var propertyHashtable = (Hashtable)propertyInfoHashtableField.GetValue(null);
+                propertyHashtable[automationProperty.Id] = getter;
+            }
+        }
+
+        private static AutomationProperty RegisterProperty(UiaPropertyInfoHelper property)
+        {
+            var automationPropertyType = typeof(AutomationProperty);
+            var registerMethod = automationPropertyType.GetMethod("Register", BindingFlags.NonPublic | BindingFlags.Static);
+
+            using (Dispatcher.CurrentDispatcher.DisableProcessing())
+                return (AutomationProperty)registerMethod.Invoke(null, new object[] { property.Guid, property.Data.pProgrammaticName });
+        }
+
+        // we have to capture providerInterfaceType; as lambda captures are ony compiler syntactic sugar - we
+        // have to recreate its magic here by hand
+        private class Wrapper
+        {
+            private readonly Type _providerInterfaceType;
+
+            public Wrapper(Type providerInterfaceType)
+            {
+                _providerInterfaceType = providerInterfaceType;
+            }
+
+            public object WrapObjectReplacer(AutomationPeer peer, object iface)
+            {
+                var interceptor = new SendingToUIThreadInterceptor(peer);
+                return _proxyGenerator.CreateInterfaceProxyWithTarget(_providerInterfaceType, iface, interceptor);
+            }
+        }
+
+        private static void GuardUiaServerInvocation(Action invocation, Dispatcher dispatcher)
+        {
+            if (dispatcher == null)
+                throw new ElementNotAvailableException();
+            Exception remoteException = null;
+            bool completed = false;
+            dispatcher.Invoke(DispatcherPriority.Send, TimeSpan.FromMinutes(3.0), (Action)(() =>
+            {
+                try
+                {
+                    invocation();
+                }
+                catch (Exception e)
+                {
+                    remoteException = e;
+                }
+                catch
+                {
+                    remoteException = null;
+                }
+                finally
+                {
+                    completed = true;
+                }
+            }));
+            if (completed)
+            {
+                if (remoteException != null)
+                    throw remoteException;
+            }
+            else if (dispatcher.HasShutdownStarted)
+                throw new InvalidOperationException("AutomationDispatcherShutdown");
+            else
+                throw new TimeoutException("AutomationTimeout");
+        }
+
+        private class StandalonePropertyGetter
+        {
+            private readonly AutomationProperty _property;
+
+            public StandalonePropertyGetter(AutomationProperty property)
+            {
+                _property = property;
+            }
+
+            public object Getter(AutomationPeer peer)
+            {
+                var propertyProvider = peer as IStandalonePropertyProvider;
+                if (propertyProvider == null) return null;
+                object result = null;
+                GuardUiaServerInvocation(() => result = propertyProvider.GetPropertyValue(_property), peer.Dispatcher);
+                return result;
+            }
+        }
+
+        private class SendingToUIThreadInterceptor : IInterceptor
+        {
+            private readonly Dispatcher _dispatcher;
+
+            public SendingToUIThreadInterceptor(AutomationPeer peer)
+            {
+                _dispatcher = peer.Dispatcher;
+            }
+
+            public void Intercept(IInvocation invocation)
+            {
+                GuardUiaServerInvocation(invocation.Proceed, _dispatcher);
+            }
+        }
+    }
+}

--- a/src/FlaUI.Custom/CustomPatternBase.cs
+++ b/src/FlaUI.Custom/CustomPatternBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Windows.Automation;
 
 namespace ManagedUiaCustomizationCore
 {

--- a/src/FlaUI.Custom/CustomPatternBase.cs
+++ b/src/FlaUI.Custom/CustomPatternBase.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Windows.Automation;
+
+namespace ManagedUiaCustomizationCore
+{
+    public abstract class CustomPatternBase<TProviderInterface, TPatternClientInterface> : AttributeDrivenPatternSchema
+    {
+        private readonly bool _usedInWpf;
+        private UiaPropertyInfoHelper[] _standaloneProperties;
+
+        protected CustomPatternBase(bool usedInWpf)
+            : base(typeof(TProviderInterface), typeof(TPatternClientInterface))
+        {
+            _usedInWpf = usedInWpf;
+            ReflectStandaloneProperties();
+            Register();
+            if (_usedInWpf)
+                AutomationPeerAugmentationHelper.Register(this);
+            FillRegistrationInfo();
+        }
+
+        public override UiaPropertyInfoHelper[] StandaloneProperties
+        {
+            get { return _standaloneProperties; }
+        }
+
+        private void ReflectStandaloneProperties()
+        {
+            var t = GetType();
+            var fs = t.GetStaticFieldsMarkedWith<StandalonePropertyAttribute>();
+            var standaloneProps = new List<UiaPropertyInfoHelper>();
+            foreach (var fieldInfo in fs)
+            {
+                if (!fieldInfo.Name.EndsWith("Property"))
+                    throw new ArgumentException("Field {0} marked with StandalonePropertyAttribute but named incorrectly. Should be XxxProperty, where Xxx is the programmatic name of the property being registered");
+                var programmaticName = fieldInfo.Name.Remove(fieldInfo.Name.Length - "Property".Length);
+                var attr = fieldInfo.GetAttribute<StandalonePropertyAttribute>();
+                var uiaType = UiaTypesHelper.TypeToAutomationType(attr.Type);
+                standaloneProps.Add(new UiaPropertyInfoHelper(attr.Guid, programmaticName, uiaType));
+            }
+            if (standaloneProps.Count > 0)
+                _standaloneProperties = standaloneProps.ToArray();
+        }
+
+        private void FillRegistrationInfo()
+        {
+            var t = GetType();
+            if (t.Name != PatternName)
+                throw new ArgumentException(string.Format("Type is named incorrectly. Should be {0}", PatternName));
+
+            SetPatternRegistrationInfo();
+
+            foreach (var prop in Properties)
+                SetPropertyRegistrationInfo(prop);
+            if (StandaloneProperties != null)
+            {
+                foreach (var prop in StandaloneProperties)
+                SetPropertyRegistrationInfo(prop);
+            }
+        }
+
+        private void SetPatternRegistrationInfo()
+        {
+            var pri = GetType().GetField("Pattern", BindingFlags.Static | BindingFlags.Public);
+            if (pri == null)
+                throw new ArgumentException("Field Pattern not found on the type");
+
+            if (pri.FieldType == typeof(int))
+                pri.SetValue(null, PatternId);
+            else if (pri.FieldType == typeof(AutomationPattern))
+            {
+                if (!_usedInWpf)
+                    throw new ArgumentException("You can't use AutomationPattern registration info because you passed usedInWpf: false in constructor");
+                pri.SetValue(null, AutomationPattern.LookupById(PatternId));
+            }
+            else
+                throw new ArgumentException("Field Pattern should be either of type int of AutomationPattern");
+        }
+
+        private void SetPropertyRegistrationInfo(UiaPropertyInfoHelper prop)
+        {
+            var propFieldName = prop.Data.pProgrammaticName + "Property";
+            var field = GetType().GetField(propFieldName, BindingFlags.Static | BindingFlags.Public);
+            if (field == null)
+                throw new ArgumentException(string.Format("Field {0} not found on the type", propFieldName));
+            if (field.FieldType == typeof(int))
+                field.SetValue(null, prop.PropertyId);
+            else if (field.FieldType == typeof(AutomationProperty))
+            {
+                if (!_usedInWpf)
+                    throw new ArgumentException("You can't use AutomationPattern registration info because you passed usedInWpf: false in constructor");
+                field.SetValue(null, AutomationProperty.LookupById(prop.PropertyId));
+            }
+            else
+                throw new ArgumentException("Fields for properties should be either of type int of AutomationProperty");
+        }
+    }
+}

--- a/src/FlaUI.Custom/FlaUI.Custom.csproj
+++ b/src/FlaUI.Custom/FlaUI.Custom.csproj
@@ -30,6 +30,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Interop.UIAutomationClient, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\libs\Interop\4.5\Interop.UIAutomationClient.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
@@ -38,6 +41,7 @@
       <HintPath>..\libs\Interop\4.5\Interop.UIAutomationCore.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -46,9 +50,36 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AttributeDrivenPatternHelpers\AttributeDrivenPatternHandler.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\PatternClientInstanceInterceptor.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\PatternGuidAttribute.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\PatternMethodAttribute.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\PatternPropertyAttribute.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\ProviderPatternMatcher.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\ReflectionUtils.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\StandalonePropertyAttribute.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\TypeMember.cs" />
+    <Compile Include="AttributeDrivenPatternHelpers\UiaTypesHelper.cs" />
+    <Compile Include="AttributeDrivenPatternSchema.cs" />
+    <Compile Include="AutomationPeerAugmentationHelper.cs" />
+    <Compile Include="CustomPatternBase.cs" />
+    <Compile Include="IStandalonePropertyProvider.cs" />
+    <Compile Include="NativeMethods.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Schema\CustomClientInstanceBase.cs" />
+    <Compile Include="Schema\CustomPatternSchemaBase.cs" />
+    <Compile Include="Schema\ISchemaMember.cs" />
+    <Compile Include="Schema\UiaEventInfoHelper.cs" />
+    <Compile Include="Schema\UiaMethodInfoHelper.cs" />
+    <Compile Include="Schema\UiaParameterDescription.cs" />
+    <Compile Include="Schema\UiaParameterHelper.cs" />
+    <Compile Include="Schema\UiaParameterListHelper.cs" />
+    <Compile Include="Schema\UiaPatternInfoHelper.cs" />
+    <Compile Include="Schema\UiaPropertyInfoHelper.cs" />
+    <Compile Include="UiaCallFailedException.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FlaUI.Core\FlaUI.Core.csproj">
@@ -56,7 +87,9 @@
       <Name>FlaUI.Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/FlaUI.Custom/IStandalonePropertyProvider.cs
+++ b/src/FlaUI.Custom/IStandalonePropertyProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Windows.Automation;
+
+namespace ManagedUiaCustomizationCore
+{
+    public interface IStandalonePropertyProvider
+    {
+        object GetPropertyValue(AutomationProperty property);
+    }
+}

--- a/src/FlaUI.Custom/NativeMethods.cs
+++ b/src/FlaUI.Custom/NativeMethods.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Runtime.InteropServices;
-using System.Windows.Automation;
 using Interop.UIAutomationCore;
 
 namespace ManagedUiaCustomizationCore
@@ -55,29 +54,10 @@ namespace ManagedUiaCustomizationCore
         private static bool ConvertException(COMException e, out Exception uiaException)
         {
             bool handled = true;
-            switch (e.ErrorCode)
-            {
-                case UIA_E_ELEMENTNOTAVAILABLE:
-                    uiaException = new ElementNotAvailableException(e);
-                    break;
 
-                case UIA_E_ELEMENTNOTENABLED:
-                    uiaException = new ElementNotEnabledException(e);
-                    break;
-
-                case UIA_E_NOCLICKABLEPOINT:
-                    uiaException = new NoClickablePointException(e);
-                    break;
-
-                case UIA_E_PROXYASSEMBLYNOTLOADED:
-                    uiaException = new ProxyAssemblyNotLoadedException(e);
-                    break;
-
-                default:
-                    uiaException = null;
-                    handled = false;
-                    break;
-            }
+            // there's no counterparts of these exceptions in FlaUI at the moment, so just return
+            // exception back
+            uiaException = e; 
             return handled;
         }
 

--- a/src/FlaUI.Custom/NativeMethods.cs
+++ b/src/FlaUI.Custom/NativeMethods.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using System.Windows.Automation;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    // P/Invoke declarations
+    public class NativeMethods
+    {
+        [DllImport("UIAutomationCore.dll", EntryPoint = "UiaHostProviderFromHwnd", CharSet = CharSet.Unicode)]
+        public static extern int UiaHostProviderFromHwnd(IntPtr hwnd, [MarshalAs(UnmanagedType.Interface)] out IRawElementProviderSimple provider);
+
+        [DllImport("UIAutomationCore.dll", EntryPoint = "UiaReturnRawElementProvider", CharSet = CharSet.Unicode)]
+        public static extern IntPtr UiaReturnRawElementProvider(IntPtr hwnd, IntPtr wParam, IntPtr lParam, IRawElementProviderSimple el);
+
+        [DllImport("UIAutomationCore.dll", EntryPoint = "UiaRaiseAutomationEvent", CharSet = CharSet.Unicode)]
+        public static extern int UiaRaiseAutomationEvent(IRawElementProviderSimple el, int eventId);
+
+        [DllImport("UIAutomationCore.dll", EntryPoint = "UiaRaiseAutomationPropertyChangedEvent", CharSet = CharSet.Unicode)]
+        public static extern int UiaRaiseAutomationPropertyChangedEvent(IRawElementProviderSimple el, int propertyId, object oldValue, object newValue);
+
+        public static void WrapUiaComCall(Func<int> preservesigCall)
+        {
+            try
+            {
+                var hr = preservesigCall();
+                if (hr != 0)
+                    throw Marshal.GetExceptionForHR(hr);
+            }
+            catch (COMException e)
+            {
+                Exception newEx;
+                if (ConvertException(e, out newEx))
+                    throw newEx;
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new UiaCallFailedException("Automation call failure", e);
+            }
+            catch
+            {
+                throw new UiaCallFailedException("Automation call failure");
+            }
+        }
+
+        #region Taken from UIAComWrapper - exception wrapping
+
+        private const int UIA_E_ELEMENTNOTAVAILABLE = -2147220991;
+        private const int UIA_E_ELEMENTNOTENABLED = -2147220992;
+        private const int UIA_E_NOCLICKABLEPOINT = -2147220990;
+        private const int UIA_E_PROXYASSEMBLYNOTLOADED = -2147220989;
+
+        private static bool ConvertException(COMException e, out Exception uiaException)
+        {
+            bool handled = true;
+            switch (e.ErrorCode)
+            {
+                case UIA_E_ELEMENTNOTAVAILABLE:
+                    uiaException = new ElementNotAvailableException(e);
+                    break;
+
+                case UIA_E_ELEMENTNOTENABLED:
+                    uiaException = new ElementNotEnabledException(e);
+                    break;
+
+                case UIA_E_NOCLICKABLEPOINT:
+                    uiaException = new NoClickablePointException(e);
+                    break;
+
+                case UIA_E_PROXYASSEMBLYNOTLOADED:
+                    uiaException = new ProxyAssemblyNotLoadedException(e);
+                    break;
+
+                default:
+                    uiaException = null;
+                    handled = false;
+                    break;
+            }
+            return handled;
+        }
+
+        #endregion
+    }
+}

--- a/src/FlaUI.Custom/Schema/CustomClientInstanceBase.cs
+++ b/src/FlaUI.Custom/Schema/CustomClientInstanceBase.cs
@@ -1,0 +1,67 @@
+﻿using System.Diagnostics;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    ///     Base class for a custom pattern's client instance.
+    ///     Responsible for hiding some of the details of marshalling client-side custom calls;
+    ///     this is mostly syntactic sugar to keep the custom pattern instance neat.
+    /// </summary>
+    public class CustomClientInstanceBase
+    {
+        protected IUIAutomationPatternInstance PatternInstance;
+
+        protected CustomClientInstanceBase(IUIAutomationPatternInstance patternInstance)
+        {
+            PatternInstance = patternInstance;
+        }
+
+        // Get a current property value for this custom property
+        protected object GetCurrentPropertyValue(UiaPropertyInfoHelper propInfo)
+        {
+            var param = new UiaParameterHelper(propInfo.UiaType);
+            PatternInstance.GetProperty(propInfo.Index, 0 /* fCached */, param.GetUiaType(), param.Data);
+            return param.Value;
+        }
+
+        // Get a current property value by calling a method, rather than by using GetProperty
+        protected object GetCurrentPropertyValueViaMethod(UiaMethodInfoHelper methodInfo)
+        {
+            // Create and init a parameter list
+            var paramList = new UiaParameterListHelper(methodInfo);
+            Debug.Assert(paramList.Count == 1);
+
+            // Call through
+            PatternInstance.CallMethod(methodInfo.Index, paramList.Data, paramList.Count);
+
+            // Return the out-parameter
+            return paramList[0];
+        }
+
+        // Get a cached property value for this custom property
+        protected object GetCachedPropertyValue(UiaPropertyInfoHelper propInfo)
+        {
+            var param = new UiaParameterHelper(propInfo.UiaType);
+            PatternInstance.GetProperty(propInfo.Index, 1 /* fCached */, param.GetUiaType(), param.Data);
+            return param.Value;
+        }
+
+        // Call a pattern instance method with this parameter list
+        protected void CallMethod(UiaMethodInfoHelper methodInfo, UiaParameterListHelper paramList)
+        {
+            PatternInstance.CallMethod(methodInfo.Index, paramList.Data, paramList.Count);
+        }
+
+        // Call a pattern instance method with only in-params
+        protected void CallMethod(UiaMethodInfoHelper methodInfo, params object[] methodParams)
+        {
+            // Create and init a parameter list
+            var paramList = new UiaParameterListHelper(methodInfo);
+            paramList.Initialize(methodParams);
+
+            // Call through
+            PatternInstance.CallMethod(methodInfo.Index, paramList.Data, paramList.Count);
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/CustomPatternSchemaBase.cs
+++ b/src/FlaUI.Custom/Schema/CustomPatternSchemaBase.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections.Generic;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    /// Base class for defining a custom schema.
+    /// Responsible for defining the minimum info for a custom schema and
+    /// registering it with UI Automation.
+    /// This class is not required by UIA and doesn't correspond to anything in UIA;
+    /// it's a personal preference about the right way to represent what is similar
+    /// between various schemas and what varies.
+    /// </summary>
+    public abstract class CustomPatternSchemaBase
+    {
+        private readonly Dictionary<uint, ISchemaMember> _members = new Dictionary<uint, ISchemaMember>();
+        private int _patternId;
+        private int _patternAvailablePropertyId;
+        private bool _registered;
+
+        // The abstract properties define the minimal data needed to express
+        // a custom pattern.
+
+        /// <summary>
+        /// The list of properties for this pattern.
+        /// </summary>
+        public abstract UiaPropertyInfoHelper[] Properties { get; }
+
+        /// <summary>
+        /// It is just a convenient shortcut. Because UIA on Win7 has a bug which doesn't allow
+        /// to register more than two custom properties for given custom pattern, some properties
+        /// that ideally should belong to pattern would be registered standalone. This is the list
+        /// of such properties.
+        /// </summary>
+        public virtual UiaPropertyInfoHelper[] StandaloneProperties
+        {
+            get { return null; }
+        }
+
+        /// <summary>
+        /// The list of methods for this pattern.
+        /// </summary>
+        public abstract UiaMethodInfoHelper[] Methods { get; }
+
+        /// <summary>
+        /// The list of events for this pattern.
+        /// </summary>
+        public abstract UiaEventInfoHelper[] Events { get; }
+
+        /// <summary>
+        /// The unique ID for this pattern.
+        /// </summary>
+        public abstract Guid PatternGuid { get; }
+
+        /// <summary>
+        /// The interface ID for the COM interface for this pattern on the client side.
+        /// </summary>
+        public virtual Guid PatternClientGuid
+        {
+            get { return PatternClientInterface.GUID; }
+        }
+
+        /// <summary>
+        /// The interface ID for the COM interface for this pattern on the provider side.
+        /// </summary>
+        public virtual Guid PatternProviderGuid
+        {
+            get { return PatternProviderInterface.GUID; }
+        }
+
+        /// <summary>
+        /// The programmatic name for this pattern.
+        /// </summary>
+        public abstract string PatternName { get; }
+
+        /// <summary>
+        /// Type of the provider interface
+        /// </summary>
+        public abstract Type PatternProviderInterface { get; }
+
+        /// <summary>
+        /// Type of the client-side interface
+        /// </summary>
+        public abstract Type PatternClientInterface { get; }
+
+        /// <summary>
+        /// An object that implements IUIAutomationPatternHandler to handle
+        /// dispatching and client-pattern creation for this pattern
+        /// </summary>
+        public abstract IUIAutomationPatternHandler Handler { get; }
+
+        /// <summary>
+        /// The assigned ID for this pattern.
+        /// </summary>
+        public int PatternId
+        {
+            get { return _patternId; }
+        }
+
+        /// <summary>
+        /// The assigned ID for the IsXxxxPatternAvailable property.
+        /// </summary>
+        public int PatternAvailablePropertyId
+        {
+            get { return _patternAvailablePropertyId; }
+        }
+
+        /// <summary>
+        /// Helper method to register this pattern.
+        /// </summary>
+        public void Register()
+        {
+            if (_registered) return;
+
+            // Get our pointer to the registrar
+            IUIAutomationRegistrar registrar = new CUIAutomationRegistrarClass();
+
+            // Set up the pattern struct
+            var patternInfo = new UiaPatternInfoHelper(PatternGuid,
+                                                       PatternName,
+                                                       PatternClientGuid,
+                                                       PatternProviderGuid,
+                                                       Handler);
+
+            // Populate it with properties and methods
+            uint index = 0;
+            foreach (var propertyInfo in Properties)
+            {
+                patternInfo.AddProperty(propertyInfo);
+                propertyInfo.Index = index++;
+                if (propertyInfo.SupportsDispatch)
+                    _members[propertyInfo.Index] = propertyInfo;
+            }
+            foreach (var methodInfo in Methods)
+            {
+                patternInfo.AddMethod(methodInfo);
+                methodInfo.Index = index++;
+                if (methodInfo.SupportsDispatch)
+                    _members[methodInfo.Index] = methodInfo;
+            }
+
+            // Add the events, too, although they are not indexed
+            foreach (var eventInfo in Events)
+            {
+                patternInfo.AddEvent(eventInfo);
+            }
+
+            // Register the pattern
+            var patternData = patternInfo.Data;
+
+            // Call register pattern
+            int[] propertyIds = new int[patternData.cProperties];
+            int[] eventIds = new int[patternData.cEvents];
+            registrar.RegisterPattern(ref patternData,
+                                      out _patternId,
+                                      out _patternAvailablePropertyId,
+                                      patternData.cProperties,
+                                      propertyIds,
+                                      patternData.cEvents,
+                                      eventIds);
+
+            // Write the property IDs back
+            for (uint i = 0; i < propertyIds.Length; ++i)
+            {
+                Properties[i].PropertyId = propertyIds[i];
+            }
+            for (var i = 0; i < eventIds.Length; ++i)
+            {
+                Events[i].EventId = eventIds[i];
+            }
+
+            if (StandaloneProperties != null)
+                RegisterStandaloneProperties(registrar);
+
+            _registered = true;
+        }
+
+        private void RegisterStandaloneProperties(IUIAutomationRegistrar registrar)
+        {
+            foreach (var propertyInfoHelper in StandaloneProperties)
+            {
+                int id;
+                var propInfo = propertyInfoHelper.Data;
+                registrar.RegisterProperty(ref propInfo, out id);
+                propertyInfoHelper.PropertyId = id;
+            }
+        }
+
+        public ISchemaMember GetMemberByIndex(uint index)
+        {
+            if (!_registered)
+                throw new InvalidOperationException("Pattern schema should be registered first");
+
+            ISchemaMember result;
+            if (_members.TryGetValue(index, out result))
+                return result;
+            return null;
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/ISchemaMember.cs
+++ b/src/FlaUI.Custom/Schema/ISchemaMember.cs
@@ -1,0 +1,8 @@
+﻿namespace ManagedUiaCustomizationCore
+{
+    public interface ISchemaMember
+    {
+        void DispatchCallToProvider(object provider, UiaParameterListHelper paramList);
+        bool SupportsDispatch { get; }
+    }
+}

--- a/src/FlaUI.Custom/Schema/UiaEventInfoHelper.cs
+++ b/src/FlaUI.Custom/Schema/UiaEventInfoHelper.cs
@@ -1,0 +1,55 @@
+using System;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    /// Helper class to gather data about a custom event
+    /// Corresponds to UIAutomationEventInfo.
+    /// </summary>
+    public class UiaEventInfoHelper
+    {
+        private readonly Guid _eventGuid;
+        private readonly string _programmaticName;
+        private bool _built;
+        private UIAutomationEventInfo _data;
+
+        public UiaEventInfoHelper(Guid eventGuid, string programmaticName)
+        {
+            _programmaticName = programmaticName;
+            _eventGuid = eventGuid;
+        }
+
+        /// <summary>
+        /// Get a marshalled UIAutomationEventInfo struct for this Helper.
+        /// </summary>
+        public UIAutomationEventInfo Data
+        {
+            get
+            {
+                if (!_built)
+                    Build();
+                return _data;
+            }
+        }
+
+        /// <summary>
+        /// The unique identifier of this event
+        /// </summary>
+        public Guid Guid
+        {
+            get { return _eventGuid; }
+        }
+
+        /// <summary>
+        /// The event ID of this event, assigned after registration
+        /// </summary>
+        public int EventId { get; set; }
+
+        private void Build()
+        {
+            _data = new UIAutomationEventInfo {pProgrammaticName = _programmaticName, guid = _eventGuid};
+            _built = true;
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/UiaMethodInfoHelper.cs
+++ b/src/FlaUI.Custom/Schema/UiaMethodInfoHelper.cs
@@ -1,0 +1,287 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    ///     Helper class to assemble information about a custom method
+    ///     Corresponds to UIAutomationMethodInfo.
+    /// </summary>
+    public class UiaMethodInfoHelper : ISchemaMember
+    {
+        private readonly MethodInfo _providerMethodInfo;
+        private readonly Dictionary<string, int> _providerMethodInfoIndicies;
+        private readonly string _programmaticName;
+        private readonly bool _doSetFocus;
+        private readonly List<IntPtr> _inParamNames = new List<IntPtr>();
+        private readonly List<UIAutomationType> _inParamTypes = new List<UIAutomationType>();
+        private readonly List<IntPtr> _outParamNames = new List<IntPtr>();
+        private readonly List<UIAutomationType> _outParamTypes = new List<UIAutomationType>();
+        private bool _built;
+        private UIAutomationMethodInfo _data;
+
+        public UiaMethodInfoHelper(string programmaticName, bool doSetFocus, IEnumerable<UiaParameterDescription> uiaParams)
+            : this(programmaticName, doSetFocus, uiaParams, null)
+        {
+        }
+
+        /// <summary>
+        ///     You have to use this ctor if you need ISchemaMember.DispatchCallToProvider
+        /// </summary>
+        public UiaMethodInfoHelper(MethodInfo providerMethodInfo, bool doSetFocus)
+            : this(providerMethodInfo.Name, doSetFocus, BuildParamsFromProviderMethodInfo(providerMethodInfo), providerMethodInfo)
+        {
+        }
+
+        private UiaMethodInfoHelper(string programmaticName, bool doSetFocus, IEnumerable<UiaParameterDescription> uiaParams, MethodInfo providerMethodInfo)
+        {
+            _programmaticName = programmaticName;
+            _doSetFocus = doSetFocus;
+            _providerMethodInfo = providerMethodInfo;
+            if (ProviderMethodInfo != null)
+            {
+                _providerMethodInfoIndicies = new Dictionary<string, int>();
+                var args = ProviderMethodInfo.GetParameters();
+                for (int i = 0; i < args.Length; i++)
+                    _providerMethodInfoIndicies.Add(args[i].Name, i);
+            }
+
+            PatternMethodParamDescriptions = new List<UiaParameterDescription>();
+            foreach (var param in uiaParams)
+                AddParameter(param);
+        }
+
+        ~UiaMethodInfoHelper()
+        {
+            foreach (var marshalledName in _inParamNames)
+            {
+                Marshal.FreeCoTaskMem(marshalledName);
+            }
+            foreach (var marshalledName in _outParamNames)
+            {
+                Marshal.FreeCoTaskMem(marshalledName);
+            }
+
+            Marshal.FreeCoTaskMem(_data.pParameterNames);
+            Marshal.FreeCoTaskMem(_data.pParameterTypes);
+        }
+
+        public List<UiaParameterDescription> PatternMethodParamDescriptions { get; private set; }
+
+        /// <summary>
+        ///     Get a marshalled UIAutomationMethodInfo struct for this Helper.
+        /// </summary>
+        public UIAutomationMethodInfo Data
+        {
+            get
+            {
+                if (!_built)
+                {
+                    Build();
+                }
+                return _data;
+            }
+        }
+
+        /// <summary>
+        ///     The array of in-parameter types.
+        /// </summary>
+        public UIAutomationType[] InParamTypes
+        {
+            get { return _inParamTypes.ToArray(); }
+        }
+
+        /// <summary>
+        ///     The array of out-parameter types.
+        /// </summary>
+        public UIAutomationType[] OutParamTypes
+        {
+            get { return _outParamTypes.ToArray(); }
+        }
+
+        /// <summary>
+        ///     The index of this method.
+        ///     In a UIA custom pattern, every method (and pattern property)
+        ///     has an assigned index.
+        /// </summary>
+        public uint Index { get; set; }
+
+        public void AddParameter(UiaParameterDescription param)
+        {
+            if (PatternMethodParamDescriptions.Count > 0 && UiaTypesHelper.IsOutType(PatternMethodParamDescriptions.Last().UiaType) && UiaTypesHelper.IsInType(param.UiaType))
+                throw new ArgumentException("In param can't go after an out one. Please, ensure the correct order");
+            if (ProviderMethodInfo != null
+                && param.Name != UiaTypesHelper.RetParamUnspeakableName
+                && !_providerMethodInfoIndicies.ContainsKey(param.Name))
+            {
+                throw new ArgumentException("Provided provider's method info does not have argument with this name");
+            }
+
+            UIAutomationType type = param.UiaType;
+            var marshalledName = Marshal.StringToCoTaskMemUni(param.Name);
+            if (UiaTypesHelper.IsInType(type))
+            {
+                _inParamNames.Add(marshalledName);
+                _inParamTypes.Add(type);
+            }
+            else
+            {
+                _outParamNames.Add(marshalledName);
+                _outParamTypes.Add(type);
+            }
+            PatternMethodParamDescriptions.Add(param);
+        }
+
+        public void DispatchCallToProvider(object provider, UiaParameterListHelper paramList)
+        {
+            if (ProviderMethodInfo == null)
+                throw new InvalidOperationException("You need to pass providerMethodInfo if you want to call ISchemaMember.DispatchCallToProvider");
+            if (paramList.Count != PatternMethodParamDescriptions.Count)
+            {
+                var message = string.Format("Provided paramList has unexpected number of elements. Expected {0} but was {1}",
+                                            PatternMethodParamDescriptions.Count,
+                                            paramList.Count);
+                throw new ArgumentException(message, "paramList");
+            }
+
+            var providerCallParameters = new object[ProviderMethodInfo.GetParameters().Length];
+            // fill in params
+            for (int i = 0; i < PatternMethodParamDescriptions.Count; i++)
+            {
+                var desc = PatternMethodParamDescriptions[i];
+                if (UiaTypesHelper.IsInType(desc.UiaType))
+                {
+                    var providerMethodParamIdx = _providerMethodInfoIndicies[desc.Name];
+                    providerCallParameters[providerMethodParamIdx] = paramList[i];
+                }
+            }
+
+            // call provider
+            object result = null;
+            try
+            {
+                result = ProviderMethodInfo.Invoke(provider, providerCallParameters);
+            }
+            catch (TargetInvocationException e)
+            {
+                if (e.InnerException != null)
+                    throw e.InnerException;
+                throw;
+            }
+
+            // write back out params
+            for (int i = 0; i < PatternMethodParamDescriptions.Count; i++)
+            {
+                var desc = PatternMethodParamDescriptions[i];
+                if (desc.Name == UiaTypesHelper.RetParamUnspeakableName)
+                {
+                    paramList[i] = result;
+                    continue;
+                }
+                if (UiaTypesHelper.IsOutType(desc.UiaType))
+                {
+                    var providerMethodParamIdx = _providerMethodInfoIndicies[desc.Name];
+                    paramList[i] = providerCallParameters[providerMethodParamIdx];
+                }
+            }
+        }
+
+        public bool SupportsDispatch
+        {
+            get { return ProviderMethodInfo != null; }
+        }
+
+        public MethodInfo ProviderMethodInfo
+        {
+            get { return _providerMethodInfo; }
+        }
+
+        public int GetProviderMethodArgumentIndex(string argumentName)
+        {
+            if (_providerMethodInfo == null)
+                throw new InvalidOperationException("You need to pass providerMethodInfo if you want to use this method");
+
+            int res;
+            if (!_providerMethodInfoIndicies.TryGetValue(argumentName, out res))
+                res = -1;
+            return res;
+        }
+
+        /// <summary>
+        ///     Marshal our data to the UIAutomationMethodInfo struct.
+        /// </summary>
+        private void Build()
+        {
+            // Copy basic data
+            _data = new UIAutomationMethodInfo
+                    {
+                        pProgrammaticName = _programmaticName,
+                        doSetFocus = _doSetFocus ? 1 : 0,
+                        cInParameters = (uint)_inParamNames.Count,
+                        cOutParameters = (uint)_outParamNames.Count
+                    };
+            var cTotalParameters = _data.cInParameters + _data.cOutParameters;
+
+            // Allocate parameter lists and populate them
+            if (cTotalParameters > 0)
+            {
+                _data.pParameterNames = Marshal.AllocCoTaskMem((int)(cTotalParameters*Marshal.SizeOf(typeof(IntPtr))));
+                _data.pParameterTypes = Marshal.AllocCoTaskMem((int)(cTotalParameters*Marshal.SizeOf(typeof(Int32))));
+
+                var namePointer = _data.pParameterNames;
+                var typePointer = _data.pParameterTypes;
+                for (var i = 0; i < _data.cInParameters; ++i)
+                {
+                    Marshal.WriteIntPtr(namePointer, _inParamNames[i]);
+                    namePointer = (IntPtr)(namePointer.ToInt64() + Marshal.SizeOf(typeof(IntPtr)));
+                    Marshal.WriteInt32(typePointer, (int)_inParamTypes[i]);
+                    typePointer = (IntPtr)(typePointer.ToInt64() + Marshal.SizeOf(typeof(Int32)));
+                }
+
+                for (var i = 0; i < _data.cOutParameters; ++i)
+                {
+                    Marshal.WriteIntPtr(namePointer, _outParamNames[i]);
+                    namePointer = (IntPtr)(namePointer.ToInt64() + Marshal.SizeOf(typeof(IntPtr)));
+                    Marshal.WriteInt32(typePointer, (int)_outParamTypes[i]);
+                    typePointer = (IntPtr)(typePointer.ToInt64() + Marshal.SizeOf(typeof(Int32)));
+                }
+            }
+            else
+            {
+                _data.pParameterNames = IntPtr.Zero;
+                _data.pParameterTypes = IntPtr.Zero;
+            }
+
+            _built = true;
+        }
+
+        private static IEnumerable<UiaParameterDescription> BuildParamsFromProviderMethodInfo(MethodInfo mInfo)
+        {
+            // Accordingly to UIA docs, In params should go before any Out params
+
+            var inParams = from parameterInfo in mInfo.GetParameters()
+                           where !parameterInfo.IsOut
+                           let uiaType = UiaTypesHelper.TypeToAutomationType(parameterInfo.ParameterType)
+                           select new UiaParameterDescription(parameterInfo.Name, uiaType);
+
+            var outParams = from parameterInfo in mInfo.GetParameters()
+                            where parameterInfo.IsOut
+                            let uiaType = UiaTypesHelper.TypeToOutAutomationType(parameterInfo.ParameterType.GetElementType())
+                            select new UiaParameterDescription(parameterInfo.Name, uiaType);
+
+            var retParam = Enumerable.Empty<UiaParameterDescription>();
+            if (mInfo.ReturnType != typeof(void))
+            {
+                var uiaRetType = UiaTypesHelper.TypeToOutAutomationType(mInfo.ReturnType);
+                var retParamDescr = new UiaParameterDescription(UiaTypesHelper.RetParamUnspeakableName, uiaRetType);
+                retParam = new[] {retParamDescr};
+            }
+
+            return inParams.Concat(outParams).Concat(retParam);
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/UiaParameterDescription.cs
+++ b/src/FlaUI.Custom/Schema/UiaParameterDescription.cs
@@ -1,0 +1,32 @@
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    /// A description of a single parameter
+    /// 
+    /// This does not match a UIA structure, but is used as a simple data class
+    /// to help form those structures.
+    /// </summary>
+    public class UiaParameterDescription
+    {
+        private readonly string _name;
+        private readonly UIAutomationType _uiaType;
+
+        public UiaParameterDescription(string name, UIAutomationType type)
+        {
+            _name = name;
+            _uiaType = type;
+        }
+
+        public string Name
+        {
+            get { return _name; }
+        }
+
+        public UIAutomationType UiaType
+        {
+            get { return _uiaType; }
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/UiaParameterHelper.cs
+++ b/src/FlaUI.Custom/Schema/UiaParameterHelper.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Runtime.InteropServices;
+using Interop.UIAutomationCore;
+using UIAutomationClient;
+using IRawElementProviderSimple = Interop.UIAutomationCore.IRawElementProviderSimple;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    /// Helper class to marshal parameters for UIA custom method calls
+    /// Corresponds to UIAutomationParameter
+    /// </summary>
+    public class UiaParameterHelper
+    {
+        private readonly UIAutomationType _uiaType;
+        private readonly Type _clrType;
+        private readonly IntPtr _marshalledData;
+        private readonly bool _ownsData;
+        private readonly bool _onClientSide;
+
+        public UiaParameterHelper(UIAutomationType type)
+        {
+            _uiaType = type;
+            _clrType = ClrTypeFromUiaType(type);
+            _marshalledData = Marshal.AllocCoTaskMem(GetSizeOfMarshalledData());
+            _ownsData = true;
+
+            // It is a safe assumption that if we are initialized without incoming data,
+            // we are on the client side.  If this changes, we can make this an explicit parameter.
+            _onClientSide = true;
+        }
+
+        public UiaParameterHelper(UIAutomationType type, IntPtr marshalledData)
+        {
+            _uiaType = type;
+            _clrType = ClrTypeFromUiaType(type);
+            _marshalledData = marshalledData;
+            _ownsData = false;
+            GC.SuppressFinalize(this);
+
+            // It is a safe assumption that if we are initialized with incoming data,
+            // we are on the provider side.  If this changes, we can make this an explicit parameter.
+            _onClientSide = false;
+        }
+
+        /// <summary>
+        /// Clean up any marshalled data attached to this object
+        /// </summary>
+        ~UiaParameterHelper()
+        {
+            if (_ownsData)
+            {
+                var basicType = _uiaType & ~UIAutomationType.UIAutomationType_Out;
+                if (basicType == UIAutomationType.UIAutomationType_String)
+                {
+                    var bstr = Marshal.ReadIntPtr(_marshalledData);
+                    Marshal.FreeBSTR(bstr);
+                }
+                else if (basicType == UIAutomationType.UIAutomationType_Element)
+                {
+                    var elementAsIntPtr = Marshal.ReadIntPtr(_marshalledData);
+                    if (elementAsIntPtr != IntPtr.Zero)
+                        Marshal.Release(elementAsIntPtr);
+                }
+
+                Marshal.FreeCoTaskMem(_marshalledData);
+            }
+        }
+
+        /// <summary>
+        /// Marshal the parameter's value to/from unmanaged code structures
+        /// </summary>
+        public object Value
+        {
+            get
+            {
+                // Get the type without the Out flag
+                var basicType = _uiaType & ~UIAutomationType.UIAutomationType_Out;
+
+                switch (basicType)
+                {
+                    case UIAutomationType.UIAutomationType_String:
+                        // Strings are held as BSTRs
+                        var bstr = Marshal.ReadIntPtr(_marshalledData);
+                        return Marshal.PtrToStringBSTR(bstr);
+                    case UIAutomationType.UIAutomationType_Bool:
+                        return 0 != (int) Marshal.PtrToStructure(_marshalledData, typeof (int));
+                    case UIAutomationType.UIAutomationType_Element:
+                        // Elements need to be copied as COM pointers
+                        var elementAsIntPtr = Marshal.ReadIntPtr(_marshalledData);
+                        return elementAsIntPtr != IntPtr.Zero ? Marshal.GetObjectForIUnknown(elementAsIntPtr) : null;
+                    default:
+                        return Marshal.PtrToStructure(_marshalledData, GetClrType());
+                }
+            }
+            set
+            {
+                // Get the type without the Out flag
+                var basicType = _uiaType & ~UIAutomationType.UIAutomationType_Out;
+
+                // Sanity check
+                if (value != null)
+                {
+                    Type valueType = value.GetType();
+                    if (valueType.IsEnum)
+                    {
+                        if (basicType != UIAutomationType.UIAutomationType_Int)
+                            throw new ArgumentException("Enum values should be passed as int");
+                    }
+                    else if (valueType != GetClrType() &&
+                             basicType != UIAutomationType.UIAutomationType_Bool &&
+                             basicType != UIAutomationType.UIAutomationType_Element)
+                    {
+                        throw new ArgumentException("Value is the wrong type for this parameter");
+                    }
+                }
+
+                switch (basicType)
+                {
+                    case UIAutomationType.UIAutomationType_String:
+                        // Strings are stored as BSTRs
+                        var bstr = Marshal.StringToBSTR((string) value);
+                        Marshal.WriteIntPtr(_marshalledData, bstr);
+                        break;
+                    case UIAutomationType.UIAutomationType_Bool:
+                        // Bools are stored as integers in UIA custom parameters
+                        var boolAsInt = ((bool) value) ? 1 : 0;
+                        Marshal.StructureToPtr(boolAsInt, _marshalledData, true);
+                        break;
+                    case UIAutomationType.UIAutomationType_Element:
+                        if (value == null)
+                        {
+                            Marshal.WriteIntPtr(_marshalledData, IntPtr.Zero);
+                            break;
+                        }
+
+                        // Elements are stored as COM pointers
+                        var interfaceType = (_onClientSide) ?
+                            typeof (IUIAutomationElement) :
+                            typeof (IRawElementProviderSimple);
+
+                        // Now we have one of interop types in the interfaceType. The problem is,
+                        // due to multiple interop assemblies (e.g. for IRawElementProviderSimple:
+                        // WPF uses its own type from UIAutomationProvider, UIAComWrapper uses its 
+                        // own type from Interop.AutomationClient, this code mostly uses one from
+                        // Interop.AutomationCore) we can't just cast managed object from one type
+                        // to another. While they represent types with same GUID, they're still
+                        // different .NET types. Thus we have to get RCW for the managed object
+                        // and ask it query through COM's IUnknown.
+                        var refiid = interfaceType.GUID;
+                        var iUnknown = Marshal.GetIUnknownForObject(value);
+                        IntPtr resultIntPtr;
+                        Marshal.QueryInterface(iUnknown, ref refiid, out resultIntPtr);
+                        Marshal.Release(iUnknown);
+                        Marshal.WriteIntPtr(_marshalledData, resultIntPtr);
+                        break;
+                    default:
+                        if (value != null && value.GetType().IsEnum)
+                            Marshal.StructureToPtr((int)value, _marshalledData, true);
+                        else
+                            Marshal.StructureToPtr(value, _marshalledData, true);
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Get the marshalled data for this helper
+        /// </summary>
+        public IntPtr Data
+        {
+            get { return _marshalledData; }
+        }
+
+        // Retrieve a UIAutomationParameter structure for this parameter
+        public UIAutomationParameter ToUiaParam()
+        {
+            UIAutomationParameter uiaParam;
+            uiaParam.type = _uiaType;
+            uiaParam.pData = _marshalledData;
+            return uiaParam;
+        }
+
+        // Get the UIA type for this parameter
+        public UIAutomationType GetUiaType()
+        {
+            return _uiaType;
+        }
+
+        // Get the CLR type for this parameter
+        public Type GetClrType()
+        {
+            return _clrType;
+        }
+
+        // Calculate how much marshalled data we'll need for this
+        private int GetSizeOfMarshalledData()
+        {
+            var basicType = _uiaType & ~UIAutomationType.UIAutomationType_Out;
+            if (basicType == UIAutomationType.UIAutomationType_String ||
+                basicType == UIAutomationType.UIAutomationType_Element)
+                return IntPtr.Size;
+            return Marshal.SizeOf(_clrType);
+        }
+
+        // Compute a CLR type from its UIA type
+        private Type ClrTypeFromUiaType(UIAutomationType uiaType)
+        {
+            // Mask off the out flag, which we don't care about.
+            uiaType = (UIAutomationType) ((int) uiaType & (int) ~UIAutomationType.UIAutomationType_Out);
+
+            switch (uiaType)
+            {
+                case UIAutomationType.UIAutomationType_Int:
+                    return typeof (int);
+                case UIAutomationType.UIAutomationType_Bool:
+                    return typeof (int); // These are BOOL, not bool
+                case UIAutomationType.UIAutomationType_String:
+                    return typeof (string);
+                case UIAutomationType.UIAutomationType_Double:
+                    return typeof (double);
+                case UIAutomationType.UIAutomationType_Element:
+                    return (_onClientSide) ? typeof (IUIAutomationElement) : typeof (IRawElementProviderSimple);
+                default:
+                    throw new ArgumentException("Type not supported by UIAutomationType");
+            }
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/UiaParameterHelper.cs
+++ b/src/FlaUI.Custom/Schema/UiaParameterHelper.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using Interop.UIAutomationClient;
 using Interop.UIAutomationCore;
-using UIAutomationClient;
 using IRawElementProviderSimple = Interop.UIAutomationCore.IRawElementProviderSimple;
 
 namespace ManagedUiaCustomizationCore

--- a/src/FlaUI.Custom/Schema/UiaParameterListHelper.cs
+++ b/src/FlaUI.Custom/Schema/UiaParameterListHelper.cs
@@ -1,0 +1,74 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    /// Helper class to assemble information about a parameter list
+    /// </summary>
+    public class UiaParameterListHelper
+    {
+        private readonly List<UiaParameterHelper> _uiaParams = new List<UiaParameterHelper>();
+
+        // Construct a parameter list from a method info structure
+        public UiaParameterListHelper(UiaMethodInfoHelper methodInfo)
+        {
+            foreach (var inParamType in methodInfo.InParamTypes)
+            {
+                _uiaParams.Add(new UiaParameterHelper(inParamType));
+            }
+            foreach (var outParamType in methodInfo.OutParamTypes)
+            {
+                _uiaParams.Add(new UiaParameterHelper(outParamType));
+            }
+        }
+
+        // Construct a parameter list from a given in-memory structure
+        public UiaParameterListHelper(UIAutomationParameter[] pParams)
+        {
+            // Construct the parameter list from the marshalled data
+            for (uint i = 0; i < pParams.Length; ++i)
+            {
+                _uiaParams.Add(new UiaParameterHelper(pParams[i].type, pParams[i].pData));
+            }
+        }
+
+        // Get a pointer to the whole parameter list marshalled into a block of memory
+        public UIAutomationParameter[] Data
+        {
+            get
+            {
+                return _uiaParams.Select(p => p.ToUiaParam()).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// The count of parameters in this list
+        /// </summary>
+        public uint Count
+        {
+            get { return (uint) _uiaParams.Count; }
+        }
+
+        // Helper method to initialize the incoming parameters list.
+        public void Initialize(params object[] inParams)
+        {
+            for (var i = 0; i < inParams.Length; ++i)
+            {
+                this[i] = inParams[i];
+            }
+        }
+
+        /// <summary>
+        /// The value of the specified parameter in this list
+        /// </summary>
+        /// <param name="i"></param>
+        /// <returns></returns>
+        public object this[int i]
+        {
+            get { return _uiaParams[i].Value; }
+            set { _uiaParams[i].Value = value; }
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/UiaPatternInfoHelper.cs
+++ b/src/FlaUI.Custom/Schema/UiaPatternInfoHelper.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    /// Helper class to assemble information about a custom pattern.
+    /// Corresponds to UIAutomationPatternInfo
+    /// </summary>
+    public class UiaPatternInfoHelper
+    {
+        private readonly Guid _patternGuid;
+        private readonly Guid _clientInterfaceId;
+        private readonly Guid _providerInterfaceId;
+        private readonly string _programmaticName;
+        private readonly IUIAutomationPatternHandler _patternHandler;
+        private readonly List<UiaMethodInfoHelper> _methods = new List<UiaMethodInfoHelper>();
+        private readonly List<UiaPropertyInfoHelper> _properties = new List<UiaPropertyInfoHelper>();
+        private readonly List<UiaEventInfoHelper> _events = new List<UiaEventInfoHelper>();
+
+        private bool _built;
+        private UIAutomationPatternInfo _data;
+
+        public UiaPatternInfoHelper(Guid patternGuid,
+                                    string programmaticName,
+                                    Guid clientInterfaceId,
+                                    Guid providerInterfaceId,
+                                    IUIAutomationPatternHandler patternHandler)
+        {
+            _programmaticName = programmaticName;
+            _patternGuid = patternGuid;
+            _clientInterfaceId = clientInterfaceId;
+            _providerInterfaceId = providerInterfaceId;
+            _patternHandler = patternHandler;
+        }
+
+        ~UiaPatternInfoHelper()
+        {
+            Marshal.FreeCoTaskMem(_data.pMethods);
+            Marshal.FreeCoTaskMem(_data.pEvents);
+            Marshal.FreeCoTaskMem(_data.pProperties);
+        }
+
+        /// <summary>
+        /// Get a marshalled UIAutomationPatternInfo struct for this Helper.
+        /// </summary>
+        public UIAutomationPatternInfo Data
+        {
+            get
+            {
+                if (!_built)
+                {
+                    Build();
+                }
+                return _data;
+            }
+        }
+
+        /// <summary>
+        /// Add a property to this pattern
+        /// </summary>
+        /// <param name="property"></param>
+        public void AddProperty(UiaPropertyInfoHelper property)
+        {
+            _properties.Add(property);
+        }
+
+        /// <summary>
+        /// Add a method to this pattern
+        /// </summary>
+        /// <param name="method"></param>
+        public void AddMethod(UiaMethodInfoHelper method)
+        {
+            _methods.Add(method);
+        }
+
+        /// <summary>
+        /// Add an event to this pattern
+        /// </summary>
+        /// <param name="eventHelper"></param>
+        public void AddEvent(UiaEventInfoHelper eventHelper)
+        {
+            _events.Add(eventHelper);
+        }
+
+        private void Build()
+        {
+            // Basic data
+            _data = new UIAutomationPatternInfo
+                    {
+                        pProgrammaticName = _programmaticName,
+                        guid = _patternGuid,
+                        clientInterfaceId = _clientInterfaceId,
+                        providerInterfaceId = _providerInterfaceId,
+                        pPatternHandler = _patternHandler,
+                        cMethods = (uint) _methods.Count
+                    };
+
+            // Build the list of methods
+            if (_data.cMethods > 0)
+            {
+                _data.pMethods = Marshal.AllocCoTaskMem((int) (_data.cMethods*Marshal.SizeOf(typeof (UIAutomationMethodInfo))));
+                var methodPointer = _data.pMethods;
+                for (var i = 0; i < _data.cMethods; ++i)
+                {
+                    Marshal.StructureToPtr(_methods[i].Data, methodPointer, false);
+                    methodPointer = (IntPtr) (methodPointer.ToInt64() + Marshal.SizeOf(typeof (UIAutomationMethodInfo)));
+                }
+            }
+            else
+            {
+                _data.pMethods = IntPtr.Zero;
+            }
+
+            // Build the list of properties
+            _data.cProperties = (uint) _properties.Count;
+            if (_data.cProperties > 0)
+            {
+                _data.pProperties = Marshal.AllocCoTaskMem((int) (_data.cProperties*Marshal.SizeOf(typeof (UIAutomationPropertyInfo))));
+                var propertyPointer = _data.pProperties;
+                for (var i = 0; i < _data.cProperties; ++i)
+                {
+                    Marshal.StructureToPtr(_properties[i].Data, propertyPointer, false);
+                    propertyPointer = (IntPtr) (propertyPointer.ToInt64() + Marshal.SizeOf(typeof (UIAutomationPropertyInfo)));
+                }
+            }
+            else
+            {
+                _data.pProperties = IntPtr.Zero;
+            }
+
+            // Build the list of events
+            _data.cEvents = (uint) _events.Count;
+            if (_data.cEvents > 0)
+            {
+                _data.pEvents = Marshal.AllocCoTaskMem((int) (_data.cEvents*Marshal.SizeOf(typeof (UIAutomationEventInfo))));
+                var eventPointer = _data.pEvents;
+                for (var i = 0; i < _data.cEvents; ++i)
+                {
+                    Marshal.StructureToPtr(_events[i].Data, eventPointer, false);
+                    eventPointer = (IntPtr) (eventPointer.ToInt64() + Marshal.SizeOf(typeof (UIAutomationEventInfo)));
+                }
+            }
+            else
+            {
+                _data.pEvents = IntPtr.Zero;
+            }
+
+            _built = true;
+        }
+    }
+}

--- a/src/FlaUI.Custom/Schema/UiaPropertyInfoHelper.cs
+++ b/src/FlaUI.Custom/Schema/UiaPropertyInfoHelper.cs
@@ -1,0 +1,106 @@
+using System;
+using Interop.UIAutomationCore;
+
+namespace ManagedUiaCustomizationCore
+{
+    /// <summary>
+    /// Helper class to gather data about a custom property
+    /// Corresponds to UIAutomationPropertyInfo
+    /// </summary>
+    public class UiaPropertyInfoHelper : ISchemaMember
+    {
+        private readonly Guid _propertyGuid;
+        private readonly string _programmaticName;
+        private readonly UIAutomationType _propertyType;
+        private readonly Func<object, object> _getterFromProvider;
+        private bool _built;
+        private UIAutomationPropertyInfo _data;
+
+        /// <summary>
+        /// Suitable for standalone properties that do not require handlers, hence no need to use ISchemaMember.DispatchCallToProvider() ever.
+        /// </summary>
+        public UiaPropertyInfoHelper(Guid propertyGuid, string programmaticName, UIAutomationType propertyType)
+            :this(propertyGuid, programmaticName, propertyType, null)
+        {
+        }
+
+        /// <summary>
+        /// Usable for general-purpose implementation that uses ISchemaMember.DispatchCallToProvider()
+        /// </summary>
+        /// <param name="getterFromProvider">Lambda for getting property value from pattern provider interface. It should be akin to
+        /// <code>(object p) => ((ISomePatternProvider)p).MyProperty</code>. Or, same thing, 
+        /// <code>TypeMember&lt;ISomePatternProvider&gt;.GetPropertyGetter(p => p.MyProperty)</code>. For standalone properties
+        /// it can be null (it is used for pattern handler implementation only, which doesn't take part in getting standalone properties).</param>
+        public UiaPropertyInfoHelper(Guid propertyGuid, string programmaticName, UIAutomationType propertyType, Func<object, object> getterFromProvider)
+        {
+            _programmaticName = programmaticName;
+            _propertyGuid = propertyGuid;
+            _propertyType = propertyType;
+            _getterFromProvider = getterFromProvider;
+        }
+
+        /// <summary>
+        /// Get a marshalled UIAutomationPropertyInfo struct for this Helper.
+        /// </summary>
+        public UIAutomationPropertyInfo Data
+        {
+            get
+            {
+                if (!_built)
+                    Build();
+                return _data;
+            }
+        }
+
+        /// <summary>
+        /// The UIA type of this property
+        /// </summary>
+        public UIAutomationType UiaType
+        {
+            get { return _propertyType; }
+        }
+
+        /// <summary>
+        /// The unique identifier for this property
+        /// </summary>
+        public Guid Guid
+        {
+            get { return _propertyGuid; }
+        }
+
+        /// <summary>
+        /// The index of this property, when it is used as part of a pattern
+        /// </summary>
+        public uint Index { get; set; }
+
+        /// <summary>
+        /// The property ID of this property, assigned after registration
+        /// </summary>
+        public int PropertyId { get; set; }
+
+        private void Build()
+        {
+            _data = new UIAutomationPropertyInfo
+                    {
+                        pProgrammaticName = _programmaticName,
+                        guid = _propertyGuid,
+                        type = _propertyType
+                    };
+            _built = true;
+        }
+
+        public void DispatchCallToProvider(object provider, UiaParameterListHelper paramList)
+        {
+            if (_getterFromProvider == null)
+                throw new InvalidOperationException("You have to provide getterFromProvider lambda argument to constructor in order to use this method");
+            if (paramList.Count != 1) 
+                throw new ArgumentException("For a property param list should contain only one out param");
+            paramList[0] = _getterFromProvider(provider);
+        }
+
+        public bool SupportsDispatch
+        {
+            get { return _getterFromProvider != null; }
+        }
+    }
+}

--- a/src/FlaUI.Custom/UiaCallFailedException.cs
+++ b/src/FlaUI.Custom/UiaCallFailedException.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace ManagedUiaCustomizationCore
+{
+    [Serializable]
+    public class UiaCallFailedException : Exception
+    {
+        public UiaCallFailedException()
+        {
+        }
+
+        public UiaCallFailedException(string message) : base(message)
+        {
+        }
+
+        public UiaCallFailedException(string message, Exception inner) : base(message, inner)
+        {
+        }
+
+        protected UiaCallFailedException(
+            SerializationInfo info,
+            StreamingContext context) : base(info, context)
+        {
+        }
+    }
+}

--- a/src/FlaUI.Custom/packages.config
+++ b/src/FlaUI.Custom/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
+</packages>

--- a/src/FlaUI.UIA2/AutomationElementInformation.cs
+++ b/src/FlaUI.UIA2/AutomationElementInformation.cs
@@ -1,0 +1,25 @@
+﻿using FlaUI.Core;
+using FlaUI.Core.Identifiers;
+using FlaUI.Core.Shapes;
+using UIA = System.Windows.Automation;
+
+namespace FlaUI.UIA2
+{
+    public class AutomationElementInformation : InformationBase2, IAutomationElementInformation
+    {
+        public AutomationElementInformation(AutomationElementBase automationElement, bool cached)
+            : base(automationElement, cached)
+        {
+        }
+
+        public string AutomationId { get { return Get<string>(AutomationIdProperty); } }
+        public Rectangle BoundingRectangle { get { return Get<Rectangle>(BoundingRectangleProperty); } }
+        public string Name { get { return Get<string>(NameProperty); } }
+
+        #region Ids
+        public static readonly PropertyId AutomationIdProperty = PropertyId.Register(AutomationLibraryType.UIA2, UIA.AutomationElementIdentifiers.AutomationIdProperty.Id, "AutomationId");
+        public static readonly PropertyId BoundingRectangleProperty = PropertyId.Register(AutomationLibraryType.UIA2, UIA.AutomationElementIdentifiers.BoundingRectangleProperty.Id, "BoundingRectangle").SetConverter(o => { var rect = (System.Windows.Rect)o; return new Rectangle(rect.X, rect.Y, rect.Width, rect.Height); });
+        public static readonly PropertyId NameProperty = PropertyId.Register(AutomationLibraryType.UIA2, UIA.AutomationElementIdentifiers.NameProperty.Id, "Name");
+        #endregion Ids
+    }
+}

--- a/src/FlaUI.UIA2/UIA2AutomationElement.cs
+++ b/src/FlaUI.UIA2/UIA2AutomationElement.cs
@@ -1,0 +1,31 @@
+﻿using FlaUI.Core;
+using UIA = System.Windows.Automation;
+
+namespace FlaUI.UIA2
+{
+    public class UIA2AutomationElement : AutomationElementBase
+    {
+        public UIA2AutomationElement(UIA2Automation automation, UIA.AutomationElement wrappedElement)
+            : base(automation)
+        {
+            WrappedElement = wrappedElement;
+        }
+
+        public UIA.AutomationElement WrappedElement { get; private set; }
+
+        protected override object InternalGetPropertyValue(int propertyId, bool cached, bool useDefaultIfNotSupported)
+        {
+            var ignoreDefaultValue = !useDefaultIfNotSupported;
+            var property = UIA.AutomationProperty.LookupById(propertyId);
+            var returnValue = cached ?
+                WrappedElement.GetCachedPropertyValue(property, ignoreDefaultValue) :
+                WrappedElement.GetCurrentPropertyValue(property, ignoreDefaultValue);
+            return returnValue;
+        }
+
+        protected override IAutomationElementInformation CreateInformation(bool cached)
+        {
+            return new AutomationElementInformation(this, cached);
+        }
+    }
+}

--- a/src/FlaUI.UIA2/UIA2Extensions.cs
+++ b/src/FlaUI.UIA2/UIA2Extensions.cs
@@ -1,0 +1,91 @@
+﻿using FlaUI.Core.Definitions;
+using FlaUI.Core.Elements;
+using FlaUI.Core.Identifiers;
+using System;
+using System.Linq;
+using LegacyUIA = System.Windows.Automation;
+
+namespace FlaUI.UIA2
+{
+    public static class UIA2Extensions
+    {
+        public static LegacyUia GetUIA2(this AutomationElement automationElement)
+        {
+            return new LegacyUia(automationElement);
+        }
+
+        public class LegacyUia
+        {
+            private readonly AutomationElement _element;
+            public LegacyUia(AutomationElement element) { _element = element; }
+
+            public void RegisterEvent(EventId @event, TreeScope treeScope, Action<AutomationElement, EventId> action)
+            {
+                var legacyEvent = LegacyUIA.AutomationEvent.LookupById(@event.Id);
+                if (legacyEvent == null) { return; }
+                LegacyUIA.Automation.AddAutomationEventHandler(legacyEvent, GetLegacyElement(), (LegacyUIA.TreeScope)treeScope,
+                    (sender, e) =>
+                    {
+                        var legacyElement = (LegacyUIA.AutomationElement)sender;
+                        var senderElement = GetNewElement(legacyElement);
+                        action(senderElement, EventId.Find(e.EventId.Id));
+                    }
+                );
+            }
+
+            public void RegisterFocusChangedEvent(Action<AutomationElement> action)
+            {
+                LegacyUIA.Automation.AddAutomationFocusChangedEventHandler(
+                    (sender, e) =>
+                    {
+                        // TODO: Any way to get the element?
+                        action(null);
+                    }
+                );
+            }
+
+            public void RegisterStructureChangedEvent(TreeScope treeScope, Action<AutomationElement, StructureChangeType, int[]> action)
+            {
+                LegacyUIA.Automation.AddStructureChangedEventHandler(
+                    GetLegacyElement(), (LegacyUIA.TreeScope)treeScope,
+                    (sender, e) =>
+                    {
+                        var legacyElement = (LegacyUIA.AutomationElement)sender;
+                        var senderElement = GetNewElement(legacyElement);
+                        action(senderElement, (StructureChangeType)e.StructureChangeType, e.GetRuntimeId());
+                    }
+                );
+            }
+
+            public void RegisterPropertyChangedEvent(TreeScope treeScope, Action<AutomationElement, PropertyId, object> action, params PropertyId[] properties)
+            {
+                var propertyIds = properties.Select(p => LegacyUIA.AutomationProperty.LookupById(p.Id)).Where(p => p != null).ToArray();
+                LegacyUIA.Automation.AddAutomationPropertyChangedEventHandler(
+                    GetLegacyElement(), (LegacyUIA.TreeScope)treeScope,
+                    (sender, e) =>
+                    {
+                        var legacyElement = (LegacyUIA.AutomationElement)sender;
+                        var senderElement = GetNewElement(legacyElement);
+                        var property = PropertyId.Find(e.Property.Id);
+                        action(senderElement, property, e.NewValue);
+                    }, propertyIds
+                );
+            }
+
+            public void UnregisterAllEvents()
+            {
+                LegacyUIA.Automation.RemoveAllEventHandlers();
+            }
+
+            private LegacyUIA.AutomationElement GetLegacyElement()
+            {
+                return LegacyUIA.AutomationElement.FromHandle(_element.NativeElement.CurrentNativeWindowHandle);
+            }
+
+            private AutomationElement GetNewElement(LegacyUIA.AutomationElement legacyElement)
+            {
+                return _element.Automation.FromHandle(new IntPtr(legacyElement.Current.NativeWindowHandle));
+            }
+        }
+    }
+}

--- a/src/FlaUI.UIA3/AutomationElementInformation.cs
+++ b/src/FlaUI.UIA3/AutomationElementInformation.cs
@@ -1,0 +1,26 @@
+﻿using FlaUI.Core;
+using FlaUI.Core.Identifiers;
+using FlaUI.Core.Shapes;
+using FlaUI.Core.Tools;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.UIA3
+{
+    public class AutomationElementInformation : InformationBase2, IAutomationElementInformation
+    {
+        public AutomationElementInformation(AutomationElementBase automationElement, bool cached)
+            : base(automationElement, cached)
+        {
+        }
+
+        public string AutomationId { get { return Get<string>(AutomationIdProperty); } }
+        public Rectangle BoundingRectangle { get { return Get<Rectangle>(BoundingRectangleProperty); } }
+        public string Name { get { return Get<string>(NameProperty); } }
+
+        #region Ids
+        public static readonly PropertyId AutomationIdProperty = PropertyId.Register(AutomationLibraryType.UIA3, UIA.UIA_PropertyIds.UIA_AutomationIdPropertyId, "AutomationId");
+        public static readonly PropertyId BoundingRectangleProperty = PropertyId.Register(AutomationLibraryType.UIA3, UIA.UIA_PropertyIds.UIA_BoundingRectanglePropertyId, "BoundingRectangle").SetConverter(NativeValueConverter.ToRectangle);        
+        public static readonly PropertyId NameProperty = PropertyId.Register(AutomationLibraryType.UIA3, UIA.UIA_PropertyIds.UIA_NamePropertyId, "Name");
+        #endregion Ids
+    }
+}

--- a/src/FlaUI.UIA3/UIA3AutomationElement.cs
+++ b/src/FlaUI.UIA3/UIA3AutomationElement.cs
@@ -1,0 +1,33 @@
+﻿using FlaUI.Core;
+using UIA = interop.UIAutomationCore;
+
+namespace FlaUI.UIA3
+{
+    public class UIA3AutomationElement : AutomationElementBase
+    {
+        public UIA3AutomationElement(UIA3Automation automation, UIA.IUIAutomationElement nativeElement)
+            : base(automation)
+        {
+            NativeElement = nativeElement;
+        }
+
+        /// <summary>
+        /// Native object for the ui element
+        /// </summary>
+        public UIA.IUIAutomationElement NativeElement { get; private set; }
+
+        protected override object InternalGetPropertyValue(int propertyId, bool cached, bool useDefaultIfNotSupported)
+        {
+            var ignoreDefaultValue = useDefaultIfNotSupported ? 0 : 1;
+            var returnValue = cached ?
+                NativeElement.GetCachedPropertyValueEx(propertyId, ignoreDefaultValue) :
+                NativeElement.GetCurrentPropertyValueEx(propertyId, ignoreDefaultValue);
+            return returnValue;
+        }
+
+        protected override IAutomationElementInformation CreateInformation(bool cached)
+        {
+            return new AutomationElementInformation(this, cached);
+        }
+    }
+}


### PR DESCRIPTION
OK, I've done not too much:
1. Added copies of cs files from ManagedUiaCustomizationCore project
2. Corrected namespaces and obvious errors

Now there's a few minor questions:
- it seems FlaUI does not have specialized exceptions as UIAComWrapped has, e.g. `ElementNotAvailableException`. Those it looks for me, exposed from FlaUI as a pure COMExceptions with cryptic `int ErrorCode` property. See diff from 'Removed COM exception wrapping' commit. I'd vote to get them back, and better before 1.0 milestone, as change of thrown exceptions contract is a breaking change for a library.
- Registration of IDs for UIA patterns/properties/events is made a bit strangely: instead of taking GUID and auxiliary data like programmatic name and obtaining int id it is done backwards. Takes int and auxiliary data and does not work with GUIDs at all. As long as you work with well-known properties that exist right in the IDL and guaranteed to be constant (probably for optimization reasons) - everything is fine. But I'd not be so sure what happens if some older Windows version does not support certain property. And I'm totally sure that for custom patterns it won't work.

Now major impediments before custom uia stuff can work. Unlike UIAComWrapper it seems that FlaUI has only strongly-typed properties... and for patterns some structure as well. That means that FlaUI version should have more involved custom pattern container (was like [this](https://github.com/TestStack/uia-custom-pattern-managed/blob/master/WpfAppWithAdvTextControl/CaretPositionPattern.cs), what should be now?)
Basically it is a question about how should I define new pattern to properly integrate it with the rest of FlaUI.

Given that understanding we would have to correct `CustomPatternSchemaBase` and `AttributeDrivenPatternSchema`. The former one allows to define/register custom entities programmatically (i.e. without defining separate types for them... might be useful if you need to treat custom entity description as a data, e.g. in FlaInspect). The latter uses a class and attributes on its members to get all necessary information. Usually custom pattern authors would use this way, as it is simpler.

Schema of the custom pattern contains all info necessary to register a pattern with native UIA and later dispatch its calls as appropriate.

So what I need here next is an example of how would we define custom pattern class in FlaUI. Let's pretend the rest works and concentrate on this one first. @Roemer could you please help me with it?