### PR TITLE
Adding ToggleState property to ToggleButton class

### DIFF
--- a/src/FlaUI.Core/AutomationElements/ToggleButton.cs
+++ b/src/FlaUI.Core/AutomationElements/ToggleButton.cs
@@ -1,5 +1,6 @@
 ﻿using FlaUI.Core.AutomationElements.Infrastructure;
 using FlaUI.Core.AutomationElements.PatternElements;
+using FlaUI.Core.Definitions;
 
 namespace FlaUI.Core.AutomationElements
 {
@@ -14,6 +15,11 @@ namespace FlaUI.Core.AutomationElements
         public ToggleButton(BasicAutomationElementBase basicAutomationElement) : base(basicAutomationElement)
         {
         }
+
+        /// <summary>
+        /// Gets the current ToggleState 
+        /// </summary>
+        public ToggleState ToggleState => base.State;
 
         /// <summary>
         /// Toggles the toggle button.


### PR DESCRIPTION
Adding ToggleState property to ToggleButton class. My only thought/concern now is that ToggleButton inherits from ToggleAutomationElement instead of Button. I am not sure how much this matters, but a ToggleButton won't have the InvokePattern. When I first created a ToggleButton class, I just inherited from Button and then added the needed stuff for implementing the Toggle Pattern in that class.