### PR TITLE
fix - RegisterPropertyChangedEvent property missing

### DIFF
--- a/src/FlaUI.UIA2/UIA2BasicAutomationElement.cs
+++ b/src/FlaUI.UIA2/UIA2BasicAutomationElement.cs
@@ -112,7 +112,7 @@ namespace FlaUI.UIA2
         public override IAutomationPropertyChangedEventHandler RegisterPropertyChangedEvent(TreeScope treeScope, Action<AutomationElement, PropertyId, object> action, PropertyId[] properties)
         {
             var eventHandler = new UIA2PropertyChangedEventHandler(Automation, action);
-            UIA.Automation.AddAutomationPropertyChangedEventHandler(NativeElement, (UIA.TreeScope)treeScope, eventHandler.EventHandler);
+            UIA.Automation.AddAutomationPropertyChangedEventHandler(NativeElement, (UIA.TreeScope)treeScope, eventHandler.EventHandler, properties.Select(p => UIA.AutomationProperty.LookupById(p.Id)).ToArray());
             return eventHandler;
         }
 


### PR DESCRIPTION
When we use UIA2 and try to register property change event ,property is missing.
I have added the missed parameter.