### PR TITLE
Fixed missing WindowHandle on Capture, changed Focus and SetForeground comments

### DIFF
--- a/src/FlaUI.Core.UITests/CaptureTests.cs
+++ b/src/FlaUI.Core.UITests/CaptureTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace FlaUI.Core.UITests
 {
     [TestFixture]
-    //[Ignore("Only for local testing")]
+    [Ignore("Only for local testing")]
     public class CaptureTests
     {
         [Test]

--- a/src/FlaUI.Core.UITests/CaptureTests.cs
+++ b/src/FlaUI.Core.UITests/CaptureTests.cs
@@ -19,7 +19,7 @@ namespace FlaUI.Core.UITests
                     Assert.That(window, Is.Not.Null);
                     Assert.That(window.Title, Is.Not.Null);
                     Capture.Screen().ToFile(@"c:\temp\screen.png");
-                    Capture.Window(window).ToFile(@"c:\temp\window.png");
+                    Capture.Element(window).ToFile(@"c:\temp\window.png");
                     Capture.Rectangle(new Rectangle(0, 0, 500, 300)).ToFile(@"c:\temp\rect.png");
                     Capture.ElementRectangle(window, new Rectangle(0, 0, 50, 150)).ToFile(@"c:\temp\elemrect.png");
                 }

--- a/src/FlaUI.Core.UITests/CaptureTests.cs
+++ b/src/FlaUI.Core.UITests/CaptureTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 namespace FlaUI.Core.UITests
 {
     [TestFixture]
-    [Ignore("Only for local testing")]
+    //[Ignore("Only for local testing")]
     public class CaptureTests
     {
         [Test]
@@ -19,7 +19,7 @@ namespace FlaUI.Core.UITests
                     Assert.That(window, Is.Not.Null);
                     Assert.That(window.Title, Is.Not.Null);
                     Capture.Screen().ToFile(@"c:\temp\screen.png");
-                    Capture.Element(window).ToFile(@"c:\temp\window.png");
+                    Capture.Window(window).ToFile(@"c:\temp\window.png");
                     Capture.Rectangle(new Rectangle(0, 0, 500, 300)).ToFile(@"c:\temp\rect.png");
                     Capture.ElementRectangle(window, new Rectangle(0, 0, 50, 150)).ToFile(@"c:\temp\elemrect.png");
                 }

--- a/src/FlaUI.Core/AutomationElements/Infrastructure/AutomationElement.cs
+++ b/src/FlaUI.Core/AutomationElements/Infrastructure/AutomationElement.cs
@@ -209,8 +209,8 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         }
 
         /// <summary>
-        /// Sets the focus to this element.
-        /// Warning: This can be unreliable! <see cref="SetForeground" /> should be more reliable.
+        /// Sets the focus to a control
+        /// Warning: For windows use <see cref="SetForeground" /> instead.
         /// </summary>
         public virtual void Focus()
         {
@@ -236,7 +236,8 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         }
 
         /// <summary>
-        /// Brings the element to the foreground.
+        /// Brings a window to the foreground.
+        /// Warning: For controls other than windows use <see cref="Focus" /> instead.
         /// </summary>
         public void SetForeground()
         {

--- a/src/FlaUI.Core/AutomationElements/Infrastructure/AutomationElement.cs
+++ b/src/FlaUI.Core/AutomationElements/Infrastructure/AutomationElement.cs
@@ -209,12 +209,18 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         }
 
         /// <summary>
-        /// Sets the focus to a control
-        /// Warning: For windows use <see cref="SetForeground" /> instead.
+        /// Sets the focus to a control. If the control is a window, brings it to the foreground.
         /// </summary>
-        public virtual void Focus()
+        public void Focus()
         {
-            BasicAutomationElement.SetFocus();
+            if (ControlType == ControlType.Window)
+            {
+                SetForeground();
+            }
+            else
+            {
+                FocusNative();
+            }
         }
 
         /// <summary>
@@ -222,36 +228,37 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         /// </summary>
         public void FocusNative()
         {
-            var windowHandle = Properties.NativeWindowHandle;
-            if (windowHandle != new IntPtr(0))
+            if (Properties.NativeWindowHandle.IsSupported)
             {
-                User32.SetFocus(windowHandle);
-                Wait.UntilResponsive(this);
+                var windowHandle = Properties.NativeWindowHandle.ValueOrDefault;
+                if (windowHandle != new IntPtr(0))
+                {
+                    User32.SetFocus(windowHandle);
+                    Wait.UntilResponsive(this);
+                    return;
+                }
             }
-            else
-            {
-                // Fallback to the UIA Version
-                Focus();
-            }
+            // Fallback to the UIA Version
+            SetFocus();
         }
 
         /// <summary>
         /// Brings a window to the foreground.
-        /// Warning: For controls other than windows use <see cref="Focus" /> instead.
         /// </summary>
         public void SetForeground()
         {
-            var windowHandle = Properties.NativeWindowHandle;
-            if (windowHandle != new IntPtr(0))
+            if (Properties.NativeWindowHandle.IsSupported)
             {
-                User32.SetForegroundWindow(windowHandle);
-                Wait.UntilResponsive(this);
+                var windowHandle = Properties.NativeWindowHandle.ValueOrDefault;
+                if (windowHandle != new IntPtr(0))
+                {
+                    User32.SetForegroundWindow(windowHandle);
+                    Wait.UntilResponsive(this);
+                    return;
+                }
             }
-            else
-            {
-                // Fallback to the UIA Version
-                Focus();
-            }
+            // Fallback to the UIA Version
+            SetFocus();
         }
 
         /// <summary>
@@ -657,6 +664,14 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
             }
             return default(TRet);
         }
+
+        /// <summary>
+        /// Sets focus onto control using UIA native element
+        /// </summary>
+        protected virtual void SetFocus()
+        {
+            BasicAutomationElement.SetFocus();
+        } 
 
         #region Conversion Methods
         /// <summary>

--- a/src/FlaUI.Core/Capture.cs
+++ b/src/FlaUI.Core/Capture.cs
@@ -26,15 +26,6 @@ namespace FlaUI.Core
         /// <summary>
         /// Captures an element and returns the image.
         /// </summary>
-        public static CaptureImage Window(AutomationElements.Window window)
-        {
-            window.SetForeground();
-            return Rectangle(window.Properties.BoundingRectangle.Value);
-        }
-
-        /// <summary>
-        /// Captures an element and returns the image.
-        /// </summary>
         public static CaptureImage Element(AutomationElement element)
         {
             element.Focus();

--- a/src/FlaUI.Core/Capture.cs
+++ b/src/FlaUI.Core/Capture.cs
@@ -26,9 +26,18 @@ namespace FlaUI.Core
         /// <summary>
         /// Captures an element and returns the image.
         /// </summary>
+        public static CaptureImage Window(AutomationElements.Window window)
+        {
+            window.SetForeground();
+            return Rectangle(window.Properties.BoundingRectangle.Value);
+        }
+
+        /// <summary>
+        /// Captures an element and returns the image.
+        /// </summary>
         public static CaptureImage Element(AutomationElement element)
         {
-            element.SetForeground();
+            element.Focus();
             return Rectangle(element.Properties.BoundingRectangle.Value);
         }
 
@@ -37,7 +46,7 @@ namespace FlaUI.Core
         /// </summary>
         public static CaptureImage ElementRectangle(AutomationElement element, Shapes.Rectangle rectangle)
         {
-            element.SetForeground();
+            element.Focus();
             var elementBounds = element.BoundingRectangle;
             // Calculate the rectangle that should be captured
             var capturingRectangle = new Shapes.Rectangle(elementBounds.Left + rectangle.Left, elementBounds.Top + rectangle.Top, rectangle.Width, rectangle.Height);


### PR DESCRIPTION
SetForeground can only be used for windows. If a capture of a control is required it must use Focus instead of SetForeground.