### PR TITLE
Scroll into view

### DIFF
--- a/src/FlaUI.Core/AutomationElements/Infrastructure/AutomationElement.cs
+++ b/src/FlaUI.Core/AutomationElements/Infrastructure/AutomationElement.cs
@@ -324,26 +324,29 @@ namespace FlaUI.Core.AutomationElements.Infrastructure
         /// <summary>
         /// Captures the object as screenshot in <see cref="Bitmap"/> format.
         /// </summary>
-        public Bitmap Capture()
+        /// <param name="focus">Set focus on element before taking capture, default is true</param>
+        public Bitmap Capture(bool focus = true)
         {
-            return Core.Capture.Element(this).Bitmap;
+            return Core.Capture.Element(this, focus).Bitmap;
         }
 
         /// <summary>
         /// Captures the object as screenshot in a WPF friendly <see cref="BitmapImage"/> format.
         /// </summary>
-        public BitmapImage CaptureWpf()
+        /// <param name="focus">Set focus on element before taking capture, default is true</param>
+        public BitmapImage CaptureWpf(bool focus = true)
         {
-            return Core.Capture.Element(this).BitmapImage;
+            return Core.Capture.Element(this, focus).BitmapImage;
         }
 
         /// <summary>
         /// Captures the object as screenshot directly into the given file.
         /// </summary>
         /// <param name="filePath">The filepath where the screenshot should be saved.</param>
-        public void CaptureToFile(string filePath)
+        /// <param name="focus">Set focus on element before taking capture, default is true</param>
+        public void CaptureToFile(string filePath, bool focus = true)
         {
-            Core.Capture.Element(this).ToFile(filePath);
+            Core.Capture.Element(this, focus).ToFile(filePath);
         }
 
         /// <summary>

--- a/src/FlaUI.Core/Capture.cs
+++ b/src/FlaUI.Core/Capture.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 using System.Windows;
 using FlaUI.Core.AutomationElements.Infrastructure;
 using FlaUI.Core.Exceptions;
-,
+
 namespace FlaUI.Core
 {
     /// <summary>

--- a/src/FlaUI.Core/Capture.cs
+++ b/src/FlaUI.Core/Capture.cs
@@ -1,10 +1,10 @@
-﻿using System;
+using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
 using System.Windows;
 using FlaUI.Core.AutomationElements.Infrastructure;
 using FlaUI.Core.Exceptions;
-
+,
 namespace FlaUI.Core
 {
     /// <summary>
@@ -26,9 +26,11 @@ namespace FlaUI.Core
         /// <summary>
         /// Captures an element and returns the image.
         /// </summary>
-        public static CaptureImage Element(AutomationElement element)
+        public static CaptureImage Element(AutomationElement element, bool focus = true)
         {
-            element.Focus();
+            if (focus) {
+                element.Focus();
+            }
             return Rectangle(element.Properties.BoundingRectangle.Value);
         }
 

--- a/src/FlaUI.Core/Capture.cs
+++ b/src/FlaUI.Core/Capture.cs
@@ -37,9 +37,11 @@ namespace FlaUI.Core
         /// <summary>
         /// Captures a rectangle inside an element and returns the image.
         /// </summary>
-        public static CaptureImage ElementRectangle(AutomationElement element, Shapes.Rectangle rectangle)
+        public static CaptureImage ElementRectangle(AutomationElement element, Shapes.Rectangle rectangle, bool focus = true)
         {
-            element.Focus();
+            if (focus) {
+                element.Focus();
+            }
             var elementBounds = element.BoundingRectangle;
             // Calculate the rectangle that should be captured
             var capturingRectangle = new Shapes.Rectangle(elementBounds.Left + rectangle.Left, elementBounds.Top + rectangle.Top, rectangle.Width, rectangle.Height);


### PR DESCRIPTION
ScrollIntoView method which works if scrollable item does not support ScrollItemPattern.
Resolves issue #111 


Also a small change on AutomationElement.Capture...-methods since it is not always desired to put the focus on the control before a Capture is taken (Control might visually change if it gets focused).