### PR TITLE
 Default value for the ControlType enum. Fixes Issue #170

### DIFF
--- a/src/FlaUI.Core.UITests/XPathTests.cs
+++ b/src/FlaUI.Core.UITests/XPathTests.cs
@@ -104,7 +104,7 @@ namespace FlaUI.Core.UITests
                 case "de":
                     return "Pinsel";
                 default:
-                    return "Brush";
+                    return "Brushes";
             }
         }
 

--- a/src/FlaUI.Core.UITests/XPathTests.cs
+++ b/src/FlaUI.Core.UITests/XPathTests.cs
@@ -57,6 +57,35 @@ namespace FlaUI.Core.UITests
             }
         }
 
+        [Test]
+        public void PaintFindElementBelowUnknown()
+        {
+            using (var automation = TestUtilities.GetAutomation(AutomationType.UIA3))
+            {
+                var app = Application.Launch("mspaint.exe");
+                var window = app.GetMainWindow(automation);
+                var button = window.FindFirstByXPath($"//Button[@Name='{GetPaintBrushName()}']");
+
+                Assert.That(button, Is.Not.Null);
+                app.Close();
+            }
+        }
+
+        [Test]
+        public void PaintReferenceElementWithUnknownType()
+        {
+            using (var automation = TestUtilities.GetAutomation(AutomationType.UIA3))
+            {
+                var app = Application.Launch("mspaint.exe");
+                var window = app.GetMainWindow(automation);
+                var unknown = window.FindFirstByXPath("//Unknown");
+                Assert.That(unknown, Is.Not.Null);
+                app.Close();
+            }
+        }
+
+
+
         private string GetFileMenuText()
         {
             switch (OperatingSystem.CurrentCulture.TwoLetterISOLanguageName)
@@ -67,5 +96,17 @@ namespace FlaUI.Core.UITests
                     return "File";
             }
         }
+
+        private string GetPaintBrushName()
+        {
+            switch (OperatingSystem.CurrentCulture.TwoLetterISOLanguageName)
+            {
+                case "de":
+                    return "Pinsel";
+                default:
+                    return "Brush";
+            }
+        }
+
     }
 }

--- a/src/FlaUI.Core/AutomationElementXPathNavigator.cs
+++ b/src/FlaUI.Core/AutomationElementXPathNavigator.cs
@@ -56,7 +56,7 @@ namespace FlaUI.Core
         }
 
         /// <inheritdoc />
-        public override string LocalName => IsInAttribute ? GetAttributeName(_attributeIndex) : _currentElement.Properties.ControlType.Value.ToString();
+        public override string LocalName => IsInAttribute ? GetAttributeName(_attributeIndex) : _currentElement.Properties.ControlType.ValueOrDefault.ToString();
 
         /// <inheritdoc />
         public override string Name => LocalName;

--- a/src/FlaUI.Core/Definitions/ControlType.cs
+++ b/src/FlaUI.Core/Definitions/ControlType.cs
@@ -5,6 +5,12 @@
     /// </summary>
     public enum ControlType
     {
+
+        /// <summary>
+        /// Identifies an unknown control type.
+        /// </summary>
+        Unknown,
+
         /// <summary>
         /// Identifies the AppBar control type. Supported starting with Windows 8.1.
         /// </summary>


### PR DESCRIPTION
Fixes Issue #170 (and is a first step towards fixing Issue #121) by adding a default value called 'Unknown' to the ControlTpe enum.
This value is returned by TryGetValue() as well as GetValueOrDefault when the underlying library cannot determine the real control type.