### PR TITLE
Improve DataGrid support for WPF apps

### DIFF
--- a/src/FlaUI.Core.UITests/Elements/DataGridViewTests.cs
+++ b/src/FlaUI.Core.UITests/Elements/DataGridViewTests.cs
@@ -7,6 +7,7 @@ namespace FlaUI.Core.UITests.Elements
 {
     [TestFixture(AutomationType.UIA2, TestApplicationType.WinForms)]
     [TestFixture(AutomationType.UIA3, TestApplicationType.WinForms)]
+    [TestFixture(AutomationType.UIA3, TestApplicationType.Wpf)]
     public class DataGridViewTests : UITestBase
     {
         private DataGridView _dataGridView;

--- a/src/FlaUI.Core.UITests/Patterns/GridPatternTests.cs
+++ b/src/FlaUI.Core.UITests/Patterns/GridPatternTests.cs
@@ -22,7 +22,7 @@ namespace FlaUI.Core.UITests.Patterns
             var mainWindow = App.GetMainWindow(Automation);
             var tab = mainWindow.FindFirstDescendant(cf => cf.ByControlType(ControlType.Tab)).AsTab();
             var tabItem = tab.SelectTabItem(1);
-            _dataGrid = tabItem.FindFirstDescendant(cf => cf.ByAutomationId("dataGrid1"));
+            _dataGrid = tabItem.FindFirstDescendant(cf => cf.ByAutomationId("dataGridView"));
         }
 
         [Test]
@@ -32,10 +32,10 @@ namespace FlaUI.Core.UITests.Patterns
             Assert.That(dataGrid, Is.Not.Null);
             var gridPattern = dataGrid.Patterns.Grid.Pattern;
             Assert.That(gridPattern, Is.Not.Null);
-            Assert.That(gridPattern.ColumnCount.Value, Is.EqualTo(2));
+            Assert.That(gridPattern.ColumnCount.Value, Is.EqualTo(3));
             Assert.That(gridPattern.RowCount.Value, Is.EqualTo(3));
             var item = gridPattern.GetItem(1, 1);
-            Assert.That(item.Properties.Name.Value, Is.EqualTo("Patrick"));
+            Assert.That(item.Properties.Name.Value, Is.EqualTo("24"));
         }
     }
 }

--- a/src/FlaUI.Core/AutomationElements/DataGridView.cs
+++ b/src/FlaUI.Core/AutomationElements/DataGridView.cs
@@ -1,7 +1,7 @@
-﻿using System.Linq;
-using FlaUI.Core.Definitions;
+﻿using FlaUI.Core.Definitions;
 using FlaUI.Core.Patterns;
 using FlaUI.Core.Tools;
+using System.Linq;
 
 namespace FlaUI.Core.AutomationElements
 {
@@ -30,7 +30,7 @@ namespace FlaUI.Core.AutomationElements
         {
             get
             {
-                var header = FindFirstChild(cf => cf.ByName(LocalizedStrings.DataGridViewHeader));
+                var header = FindFirstChild(cf => cf.ByName(LocalizedStrings.DataGridViewHeader).Or(cf.ByControlType(ControlType.Header)));
                 return header == null ? null : new DataGridViewHeader(header.FrameworkAutomationElement);
             }
         }
@@ -42,7 +42,8 @@ namespace FlaUI.Core.AutomationElements
         {
             get
             {
-                var rows = FindAllChildren(cf => cf.ByControlType(ControlType.Custom).And(cf.ByName(LocalizedStrings.DataGridViewHeader).Not()));
+                var rows = FindAllChildren(cf => cf.ByControlType(ControlType.Custom).Or(cf.ByControlType(ControlType.DataItem))
+                    .And(cf.ByName(LocalizedStrings.DataGridViewHeader).Not()));
                 // Remove the last row if we have the "add" row
                 if (HasAddRow)
                 {
@@ -72,7 +73,8 @@ namespace FlaUI.Core.AutomationElements
         {
             get
             {
-                var headerItems = FindAllChildren(cf => cf.ByControlType(ControlType.Header));
+                // WinForms uses Header control type, WPF uses HeaderItem control type
+                var headerItems = FindAllChildren(cf => cf.ByControlType(ControlType.Header).Or(cf.ByControlType(ControlType.HeaderItem)));
                 var convertedHeaderItems = headerItems.Select(x => new DataGridViewHeaderItem(x.FrameworkAutomationElement))
                     .ToList();
                 // Remove the top-left header item if it exists (can be the first or last item)
@@ -126,7 +128,10 @@ namespace FlaUI.Core.AutomationElements
         {
             get
             {
-                var cells = FindAllChildren(cf => cf.ByControlType(ControlType.Header).Not());
+                var cells = FindAllChildren(cf => 
+                    cf.ByControlType(ControlType.Header).Not()
+                    .And(cf.ByControlType(ControlType.HeaderItem).Not())
+                    .And(cf.ByClassName("DataGridDetailsPresenter").Not()));
                 return cells.Select(x => new DataGridViewCell(x.FrameworkAutomationElement)).ToArray();
             }
         }

--- a/src/TestApplications/WpfApplication/DataGridItem.cs
+++ b/src/TestApplications/WpfApplication/DataGridItem.cs
@@ -4,15 +4,21 @@ namespace WpfApplication
 {
     public class DataGridItem : ObservableObject
     {
-        public int Id
+        public string Name
+        {
+            get => GetProperty<string>();
+            set => SetProperty(value);
+        }
+
+        public int Number
         {
             get => GetProperty<int>();
             set => SetProperty(value);
         }
 
-        public string Name
+        public bool IsChecked
         {
-            get => GetProperty<string>();
+            get => GetProperty<bool>();
             set => SetProperty(value);
         }
     }

--- a/src/TestApplications/WpfApplication/MainViewModel.cs
+++ b/src/TestApplications/WpfApplication/MainViewModel.cs
@@ -20,9 +20,8 @@ namespace WpfApplication
         {
             DataGridItems = new ObservableCollection<DataGridItem>
             {
-                new DataGridItem { Id = 1, Name = "Spongebob" },
-                new DataGridItem { Id = 2, Name = "Patrick" },
-                new DataGridItem { Id = 3, Name = "Tadeus" }
+                new DataGridItem { Name = "John", Number = 12, IsChecked = false },
+                new DataGridItem { Name = "Doe", Number = 24, IsChecked = true },
             };
 
             InvokeButtonText = "Invoke me!";

--- a/src/TestApplications/WpfApplication/MainWindow.xaml
+++ b/src/TestApplications/WpfApplication/MainWindow.xaml
@@ -168,7 +168,7 @@
                             </ListView>
                         </GroupBox>
                         <GroupBox Header="Grid">
-                            <DataGrid AutomationProperties.AutomationId="dataGrid1" CanUserAddRows="False" ItemsSource="{Binding DataGridItems}" />
+                            <DataGrid AutomationProperties.AutomationId="dataGridView" CanUserAddRows="True" ItemsSource="{Binding DataGridItems}" />
                         </GroupBox>
                     </StackPanel>
                 </ScrollViewer>


### PR DESCRIPTION
This PR addresses several issues I've noticed with interacting with WPF DataGrids.

Specifically:
- `DataGridView.Rows` always returns an empty array
- `DataGridViewRow.Cells` returns too many items (doesn't filter out the header cell)
- `DataGridView.Header` always returns null

All changes in the first commit are related to making the test WpfApplication's DataGrid control match the winforms version so tests are valid against either application type. I have tried to ensure no regressions were introduced with WinForm DataGrids.

I wasn't able to find any sort of style guide, so let me know if any code styling changes need to be made.