### PR TITLE
Switch Collapse function to correctly call the Collapse function of the expand pattern

### DIFF
--- a/src/FlaUI.Core/AutomationElements/PatternElements/ExpandCollapseAutomationElement.cs
+++ b/src/FlaUI.Core/AutomationElements/PatternElements/ExpandCollapseAutomationElement.cs
@@ -32,7 +32,7 @@ namespace FlaUI.Core.AutomationElements.PatternElements
         /// </summary>
         public void Collapse()
         {
-            ExpandCollapsePattern.Expand();
+            ExpandCollapsePattern.Collapse();
         }
     }
 }


### PR DESCRIPTION
I'm assuming this was a copy+paste issue or just a small slipup, but the `Collapse` function of all ExpandCollapseAutomationElements is actually calling the `Expand` function of the ExpandCollapsePattern.